### PR TITLE
Fixes in azure provider

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -6,6 +6,7 @@ If you are running the tests on an instance under scale set, only then you need 
 
 ```bash
 export AZURE_INSTANCE_ID=<instance-id>
+export AZURE_INSTANCE_REGION=<instance-region>
 export AZURE_SCALE_SET_NAME=<scale-set-name>
 export AZURE_SUBSCRIPTION_ID=<subscription-id>
 export AZURE_RESOURCE_GROUP_NAME=<resource-group-name-of-instance>

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -2,6 +2,7 @@ package azure_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
@@ -25,9 +26,13 @@ func initAzure(t *testing.T) (cloudops.Ops, map[string]interface{}) {
 		t.Skipf("skipping Azure tests as environment is not set...\n")
 	}
 
+	region, present := os.LookupEnv("AZURE_INSTANCE_REGION")
+	if !present {
+		t.Skipf("skipping Azure tests as AZURE_INSTANCE_REGION is not set...\n")
+	}
+
 	size := int32(newDiskSizeInGB)
 	name := diskName
-	region := "eastus2"
 
 	template := &compute.Disk{
 		Name:     &name,

--- a/azure/base_vmsclient.go
+++ b/azure/base_vmsclient.go
@@ -20,7 +20,6 @@ func newBaseVMsClient(
 	vmsClient := compute.NewVirtualMachinesClient(subscriptionID)
 	vmsClient.Authorizer = authorizer
 	vmsClient.PollingDelay = clientPollingDelay
-	vmsClient.RetryAttempts = clientRetryAttempts
 	vmsClient.AddToUserAgent(userAgentExtension)
 	return &baseVMsClient{
 		resourceGroupName: resourceGroupName,
@@ -43,7 +42,7 @@ func (b *baseVMsClient) getDataDisks(
 ) ([]compute.DataDisk, error) {
 	vm, err := b.describeInstance(instanceName)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get vm %v: %v", instanceName, err)
+		return nil, err
 	}
 
 	if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
@@ -73,12 +72,12 @@ func (b *baseVMsClient) updateDataDisks(
 		updatedVM,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot update vm %v: %v", instanceName, err)
+		return err
 	}
 
 	err = future.WaitForCompletionRef(ctx, b.client.Client)
 	if err != nil {
-		return fmt.Errorf("cannot get the vm update future response: %v", err)
+		return err
 	}
 	return nil
 }

--- a/azure/base_vmsclient.go
+++ b/azure/base_vmsclient.go
@@ -28,6 +28,10 @@ func newBaseVMsClient(
 	}
 }
 
+func (b *baseVMsClient) name(instanceName string) string {
+	return instanceName
+}
+
 func (b *baseVMsClient) describe(
 	instanceName string,
 ) (interface{}, error) {

--- a/azure/scaleset_vmsclient.go
+++ b/azure/scaleset_vmsclient.go
@@ -30,6 +30,10 @@ func newScaleSetVMsClient(
 	}
 }
 
+func (s *scaleSetVMsClient) name(instanceID string) string {
+	return s.scaleSetName + "_" + instanceID
+}
+
 func (s *scaleSetVMsClient) describe(
 	instanceID string,
 ) (interface{}, error) {

--- a/azure/scaleset_vmsclient.go
+++ b/azure/scaleset_vmsclient.go
@@ -21,7 +21,6 @@ func newScaleSetVMsClient(
 	vmsClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
 	vmsClient.Authorizer = authorizer
 	vmsClient.PollingDelay = clientPollingDelay
-	vmsClient.RetryAttempts = clientRetryAttempts
 	vmsClient.AddToUserAgent(userAgentExtension)
 	return &scaleSetVMsClient{
 		scaleSetName:      scaleSetName,
@@ -45,7 +44,7 @@ func (s *scaleSetVMsClient) getDataDisks(
 ) ([]compute.DataDisk, error) {
 	vm, err := s.describeInstance(instanceID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get vm %v_%v: %v", s.scaleSetName, instanceID, err)
+		return nil, err
 	}
 
 	if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
@@ -61,7 +60,7 @@ func (s *scaleSetVMsClient) updateDataDisks(
 ) error {
 	vm, err := s.describeInstance(instanceID)
 	if err != nil {
-		return fmt.Errorf("cannot get vm %v_%v: %v", s.scaleSetName, instanceID, err)
+		return err
 	}
 
 	vm.StorageProfile.DataDisks = &dataDisks
@@ -75,12 +74,12 @@ func (s *scaleSetVMsClient) updateDataDisks(
 		vm,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot update vm %v_%v: %v", s.scaleSetName, instanceID, err)
+		return err
 	}
 
 	err = future.WaitForCompletionRef(ctx, s.client.Client)
 	if err != nil {
-		return fmt.Errorf("cannot get the vm update future response: %v", err)
+		return err
 	}
 	return nil
 }

--- a/azure/vmsclient.go
+++ b/azure/vmsclient.go
@@ -7,6 +7,8 @@ import (
 
 // vmsClient is an interface for azure vm client operations
 type vmsClient interface {
+	// name returns the name of the instance
+	name(instanceID string) string
 	// describe returns the VM instance object
 	describe(instanceID string) (interface{}, error)
 	// getDataDisks returns a list of data disks attached to the given VM

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -400,7 +400,7 @@ func (e *exponentialBackoff) handleError(origErr error, msg string) (bool, error
 			// do an exponential backoff
 			logrus.WithFields(logrus.Fields{
 				e.cloudOps.Name() + "-error": origErr,
-			}).Errorf("%v Retrying after a backoff...", msg)
+			}).Errorf("%v Retrying after a backoff.", msg)
 			return false, nil
 		} // for all other errors return immediately
 		return true, origErr

--- a/test/cloudops.go
+++ b/test/cloudops.go
@@ -53,10 +53,16 @@ func compute(t *testing.T, driver cloudops.Ops) {
 	require.NotEmpty(t, instanceID, "failed to get instance ID")
 
 	info, err := driver.InspectInstance(instanceID)
+	if _, ok := err.(*cloudops.ErrNotSupported); ok {
+		return
+	}
 	require.NoError(t, err, "failed to inspect instance")
 	require.NotNil(t, info, "got nil instance info from inspect")
 
 	groupInfo, err := driver.InspectInstanceGroupForInstance(instanceID)
+	if _, ok := err.(*cloudops.ErrNotSupported); ok {
+		return
+	}
 	require.NoError(t, err, "failed to inspect instance group")
 	require.NotNil(t, groupInfo, "got nil instance group info from inspect")
 }
@@ -124,6 +130,7 @@ func enumerate(t *testing.T, driver cloudops.Ops, diskName string) {
 
 	require.NoError(t, err, "failed to enumerate disk")
 	require.Len(t, disks, 1, "enumerate returned invalid length")
+	require.Len(t, disks[cloudops.SetIdentifierNone], 1, "enumerate returned invalid length")
 
 	// enumerate with invalid labels
 	randomStr := uuid.New()


### PR DESCRIPTION
- Check if the disk is attached on remote node before trying to attach
- If disk is attached locally avoid the attach call
- Use multiple Get calls instead of List in Azure Inspect Disks
    - The request limit for List calls is quite low compared to the Get calls.
      List calls limit is 240/3min and 1900/30min
      Get calls limit is ~6000/3min and ~36000/30min
    - Using ListByResourceGroup instead of just List to scope the disk to
      the resource group. Also observed that the List call does not return
      a `Retry-after` header when returning 429, which the other does. This
      helps the SDK to retry after the said time instead of doing it immediately.
-  Adding Azure error AttachDiskWhileBeingDetached for exponential backoff.
    - Returning all errors as it is so the exponential error checker finds the original error.
- Detach a disk from azure vm if attach fails with AttachDiskWhileBeingDetached. When multiple VMs try to attach the same disk, Azure fails the calls but shows the disk attached to it. Any subsequent call returns AttachDiskWhileBeingDetached. To avoid this we try to do a detach prevent next attach from failing.