### PR TITLE
Add Expand API to Storage CloudOps interface.

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -25,6 +25,7 @@ import (
 	awscredentials "github.com/libopenstorage/secrets/aws/credentials"
 	"github.com/portworx/sched-ops/task"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -841,6 +842,66 @@ func (s *awsOps) detachInternal(volumeID, instanceName string) error {
 		time.Minute,
 	)
 	return err
+}
+
+func (s *awsOps) Expand(
+	volumeID string,
+	newSizeInGiB uint64,
+) (uint64, error) {
+	vol, err := s.refreshVol(&volumeID)
+	if err != nil {
+		return 0, err
+	}
+	currentSizeInGiB := uint64(*vol.Size)
+	if uint64(*vol.Size) >= newSizeInGiB {
+		return currentSizeInGiB, nil
+	}
+	newSizeInGiBInt64 := int64(newSizeInGiB)
+	request := &ec2.ModifyVolumeInput{
+		VolumeId: vol.VolumeId,
+		Size:     &newSizeInGiBInt64,
+	}
+	output, err := s.ec2.ModifyVolume(request)
+	if err != nil {
+		return currentSizeInGiB, fmt.Errorf("failed to modify AWS volume for %v: %v", volumeID, err)
+	}
+
+	if string(*output.VolumeModification.ModificationState) == ec2.VolumeModificationStateCompleted {
+		return uint64(*output.VolumeModification.TargetSize), nil
+	}
+
+	// Taken from k8s.io/legacy-cloud-providers/aws
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2,
+		Steps:    10,
+	}
+
+	checkForResize := func() (bool, error) {
+		request := &ec2.DescribeVolumesModificationsInput{
+			VolumeIds: []*string{&volumeID},
+		}
+
+		describeOutput, err := s.ec2.DescribeVolumesModifications(request)
+		if err != nil {
+			return false, fmt.Errorf("error while checking status for AWS EBS volume resize: %v", err)
+		}
+		volumeModifications := describeOutput.VolumesModifications
+		if len(volumeModifications) == 0 {
+			return false, fmt.Errorf("no volume modifications found for AWS EBS volume %v", volumeID)
+		}
+		volumeModification := volumeModifications[len(volumeModifications)-1]
+
+		// According to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring_mods.html
+		// Size changes usually take a few seconds to complete and take effect after a volume is in the Optimizing state.
+		if *volumeModification.ModificationState == ec2.VolumeModificationStateOptimizing {
+			return true, nil
+		}
+		return false, nil
+	}
+	waitWithErr := wait.ExponentialBackoff(backoff, checkForResize)
+	return newSizeInGiB, waitWithErr
+
 }
 
 func (s *awsOps) Snapshot(

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -853,9 +853,12 @@ func (s *awsOps) Expand(
 		return 0, err
 	}
 	currentSizeInGiB := uint64(*vol.Size)
-	if uint64(*vol.Size) >= newSizeInGiB {
-		return currentSizeInGiB, nil
+	if currentSizeInGiB >= newSizeInGiB {
+		return 0, cloudops.NewStorageError(cloudops.ErrDiskGreaterOrEqualToExpandSize,
+			fmt.Sprintf("disk is already has a size: %d greater than or equal "+
+				"requested size: %d", currentSizeInGiB, newSizeInGiB), "")
 	}
+
 	newSizeInGiBInt64 := int64(newSizeInGiB)
 	request := &ec2.ModifyVolumeInput{
 		VolumeId: vol.VolumeId,

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -40,7 +40,18 @@ func TestAll(t *testing.T) {
 		t.Skipf("skipping AWS tests as environment is not set...\n")
 	}
 
-	test.RunTest(drivers, diskTemplates, t)
+	test.RunTest(drivers, diskTemplates, sizeCheck, t)
+}
+
+func sizeCheck(template interface{}, targetSize uint64) bool {
+	disk, ok := template.(*ec2.Volume)
+	if !ok {
+		return false
+	}
+	if disk.Size == nil {
+		return false
+	}
+	return targetSize == uint64(*disk.Size)
 }
 
 func TestAwsGetPrefixFromRootDeviceName(t *testing.T) {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -344,8 +344,9 @@ func (a *azureOps) Expand(
 	}
 
 	if *disk.DiskProperties.DiskSizeGB >= int32(newSizeInGiB) {
-		// no work is needed
-		return uint64(*disk.DiskProperties.DiskSizeGB), nil
+		return 0, cloudops.NewStorageError(cloudops.ErrDiskGreaterOrEqualToExpandSize,
+			fmt.Sprintf("disk is already has a size: %d greater than or equal "+
+				"requested size: %d", *disk.DiskProperties.DiskSizeGB, newSizeInGiB), "")
 	}
 	oldSizeInGiB := uint64(*disk.DiskProperties.DiskSizeGB)
 	// Azure resizes in chunks of GiB even if the disk properties variable is DiskSizeGB

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -55,9 +55,19 @@ func initAzure(t *testing.T) (cloudops.Ops, map[string]interface{}) {
 func TestAll(t *testing.T) {
 	drivers := make(map[string]cloudops.Ops)
 	diskTemplates := make(map[string]map[string]interface{})
-
 	d, disks := initAzure(t)
 	drivers[d.Name()] = d
 	diskTemplates[d.Name()] = disks
-	test.RunTest(drivers, diskTemplates, t)
+	test.RunTest(drivers, diskTemplates, sizeCheck, t)
+}
+
+func sizeCheck(template interface{}, targetSize uint64) bool {
+	disk, ok := template.(*compute.Disk)
+	if !ok {
+		return false
+	}
+	if disk.DiskProperties == nil || disk.DiskProperties.DiskSizeGB == nil {
+		return false
+	}
+	return targetSize == uint64(*disk.DiskProperties.DiskSizeGB)
 }

--- a/cloudops.go
+++ b/cloudops.go
@@ -92,6 +92,11 @@ type Storage interface {
 	// Attach volumeID.
 	// Return attach path.
 	Attach(volumeID string) (string, error)
+	// Expand expands the provided device from the existing size to the new size
+	// It returns the new size of the device. It is a blocking API where it will
+	// only return once the requested size is validated with the cloud provider or
+	// the number of retries prescribed by the cloud provider are exhausted.
+	Expand(volumeID string, newSizeInGiB uint64) (uint64, error)
 	// Detach volumeID.
 	Detach(volumeID string) error
 	// DetachFrom detaches the disk/volume with given ID from the given instance ID

--- a/errors.go
+++ b/errors.go
@@ -18,6 +18,9 @@ const (
 	ErrInvalidDevicePath
 	// ErrExponentialTimeout is code when all the retries with exponential backoff have exhausted
 	ErrExponentialTimeout
+	// ErrDiskGreaterOrEqualToExpandSize is code when a volume/disk expansion call fails
+	// as the given disk is already at a size greater than or equal to requested size
+	ErrDiskGreaterOrEqualToExpandSize
 )
 
 // ErrNotSupported is the error type for unsupported operations

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -603,6 +603,16 @@ func (s *gceOps) GetDeviceID(disk interface{}) (string, error) {
 	}
 }
 
+func (s *gceOps) Expand(
+	volumeID string,
+	newSizeInGiB uint64,
+) (uint64, error) {
+	// TODO
+	return 0, &cloudops.ErrNotSupported{
+		Operation: "Expand",
+	}
+}
+
 func (s *gceOps) Inspect(diskNames []*string) ([]interface{}, error) {
 	allDisks, err := s.getDisksFromAllZones(nil)
 	if err != nil {

--- a/gce/gce_test.go
+++ b/gce/gce_test.go
@@ -45,7 +45,7 @@ func TestAll(t *testing.T) {
 		d, disks := initGCE(t)
 		drivers[d.Name()] = d
 		diskTemplates[d.Name()] = disks
-		test.RunTest(drivers, diskTemplates, t)
+		test.RunTest(drivers, diskTemplates, nil, t)
 	} else {
 		fmt.Printf("skipping GCE tests as environment is not set...\n")
 		t.Skip("skipping GCE tests as environment is not set...")

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -363,6 +363,16 @@ func (ops *vsphereOps) Enumerate(volumeIds []*string,
 	}
 }
 
+func (ops *vsphereOps) Expand(
+	volumeID string,
+	newSizeInGiB uint64,
+) (uint64, error) {
+	// TODO
+	return 0, &cloudops.ErrNotSupported{
+		Operation: "Expand",
+	}
+}
+
 // Snapshot the volume with given volumeID
 func (ops *vsphereOps) Snapshot(volumeID string, readonly bool) (interface{}, error) {
 	return nil, &cloudops.ErrNotSupported{

--- a/vsphere/vsphere_test.go
+++ b/vsphere/vsphere_test.go
@@ -56,7 +56,7 @@ func TestAll(t *testing.T) {
 		drivers[d.Name()] = d
 		diskTemplates[d.Name()] = disks
 
-		test.RunTest(drivers, diskTemplates, t)
+		test.RunTest(drivers, diskTemplates, nil, t)
 	} else {
 		fmt.Printf("skipping vSphere tests as environment is not set...\n")
 		t.Skip("skipping vSphere tests as environment is not set...")


### PR DESCRIPTION

Added Expand API to Cloudops Disk interface.  
- Currently implemented only for Azure and AWS
- Added a UT to test Expand API.