### PR TITLE
In AddDisk set the delta DriveCount in response.

### DIFF
--- a/pkg/storagedistribution/storagedistribution.go
+++ b/pkg/storagedistribution/storagedistribution.go
@@ -153,7 +153,7 @@ func AddDisk(
 		DriveType:        row.DriveType,
 		IOPS:             row.IOPS,
 		DriveCapacityGiB: currentDriveSize,
-		DriveCount:       uint64(requiredDriveCount) + request.CurrentDriveCount,
+		DriveCount:       uint64(requiredDriveCount),
 	}
 	prettyPrintStoragePoolSpec(instStorage, "AddDisk")
 	resp := &cloudops.StoragePoolUpdateResponse{

--- a/vsphere/storagemanager/vsphere_test.go
+++ b/vsphere/storagemanager/vsphere_test.go
@@ -260,7 +260,7 @@ func storageUpdate(t *testing.T) {
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 1024,
 						DriveType:        "thin",
-						DriveCount:       4,
+						DriveCount:       2,
 					},
 				},
 			},
@@ -284,7 +284,7 @@ func storageUpdate(t *testing.T) {
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 1024,
 						DriveType:        "thin",
-						DriveCount:       3,
+						DriveCount:       1,
 					},
 				},
 			},
@@ -308,7 +308,7 @@ func storageUpdate(t *testing.T) {
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 600,
 						DriveType:        "thin",
-						DriveCount:       4,
+						DriveCount:       1,
 					},
 				},
 			},


### PR DESCRIPTION
- Instead of setting the new total drive count of the storage pool, set the delta no. of
  drives that need to be provisioned.