### PR TITLE
Update azure storage distribution yaml.

### DIFF
--- a/azure/storagemanager/azure_test.go
+++ b/azure/storagemanager/azure_test.go
@@ -374,9 +374,197 @@ func storageUpdate(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			// ***** TEST: 2
+			//        Instance has 2 x 350 GiB
+			//        Update from 700GiB to 800 GiB by resizing disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     800,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK,
+				CurrentDriveSize:    350,
+				CurrentDriveType:    "Premium_LRS",
+				CurrentDriveCount:   2,
+				TotalDrivesOnNode:   2,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 400,
+						DriveType:        "Premium_LRS",
+						DriveCount:       2,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 3
+			//        Instance has 3 x 300 GiB
+			//        Update from 900GiB to 1200 GiB by resizing disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     1200,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK,
+				CurrentDriveSize:    300,
+				CurrentDriveType:    "StandardSSD_LRS",
+				CurrentDriveCount:   3,
+				TotalDrivesOnNode:   3,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 400,
+						DriveType:        "StandardSSD_LRS",
+						DriveCount:       3,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 4
+			//		  Instances has 2 x 1024 GiB
+			//        Update from 2048 GiB to  4096 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     4096,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				CurrentDriveSize:    1024,
+				CurrentDriveType:    "Premium_LRS",
+				CurrentDriveCount:   2,
+				TotalDrivesOnNode:   2,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 1024,
+						DriveType:        "Premium_LRS",
+						DriveCount:       2,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 5
+			//		  Instances has 2 x 1024 GiB
+			//        Update from 2048 GiB to  3072 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     3072,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				CurrentDriveSize:    1024,
+				CurrentDriveType:    "Standard_LRS",
+				CurrentDriveCount:   2,
+				TotalDrivesOnNode:   2,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 1024,
+						DriveType:        "Standard_LRS",
+						DriveCount:       1,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 6
+			//		  Instances has 3 x 600 GiB
+			//        Update from 1800 GiB to 2000 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     2000,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				CurrentDriveSize:    600,
+				CurrentDriveType:    "Premium_LRS",
+				CurrentDriveCount:   3,
+				TotalDrivesOnNode:   3,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 600,
+						DriveType:        "Premium_LRS",
+						DriveCount:       1,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 7
+			//		  Instances has no existing drives
+			//        Update from 0 GiB to 700 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     700,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				TotalDrivesOnNode:   0,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 700,
+						DriveType:        "Premium_LRS",
+						DriveCount:       1,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		/*{
+			// ***** TEST: 8
+			//		  Instances has no existing drives
+			//        Update from 0 GiB to 8193 GiB by adding disks. 8193 is higher
+			//        than the maximum drive in the matrix
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     8196,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				TotalDrivesOnNode:   0,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 4098,
+						DriveType:        "thin",
+						DriveCount:       2,
+					},
+				},
+			},
+			expectedErr: nil,
+		},*/
+		{
+			// ***** TEST: 9
+			//        Instance has 1 x 150 GiB
+			//        Update from 150GiB to 170 GiB by resizing disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     280,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK,
+				CurrentDriveSize:    256,
+				CurrentDriveType:    "Standard_LRS",
+				CurrentDriveCount:   1,
+				TotalDrivesOnNode:   1,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_RESIZE_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 280,
+						DriveType:        "Standard_LRS",
+						DriveCount:       1,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
 	}
 
-	for _, test := range testMatrix {
+	for i, test := range testMatrix {
+		fmt.Println("Executing test case: ", i+1)
 		response, err := storageManager.RecommendStoragePoolUpdate(test.request)
 		if test.expectedErr == nil {
 			require.Nil(t, err, "RecommendStoragePoolUpdate returned an error")

--- a/azure/storagemanager/azure_test.go
+++ b/azure/storagemanager/azure_test.go
@@ -98,9 +98,9 @@ func storageDistribution(t *testing.T) {
 			response: &cloudops.StorageDistributionResponse{
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
-						DriveCapacityGiB: 256,
+						DriveCapacityGiB: 113,
 						DriveType:        "Standard_LRS",
-						InstancesPerZone: 2,
+						InstancesPerZone: 3,
 						DriveCount:       1,
 						IOPS:             500,
 					},
@@ -269,9 +269,9 @@ func storageDistribution(t *testing.T) {
 			response: &cloudops.StorageDistributionResponse{
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
-						DriveCapacityGiB: 256,
+						DriveCapacityGiB: 111,
 						DriveType:        "Standard_LRS",
-						InstancesPerZone: 2,
+						InstancesPerZone: 3,
 						DriveCount:       1,
 						IOPS:             500,
 					},
@@ -308,9 +308,9 @@ func storageDistribution(t *testing.T) {
 			response: &cloudops.StorageDistributionResponse{
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
-						DriveCapacityGiB: 256,
+						DriveCapacityGiB: 111,
 						DriveType:        "Standard_LRS",
-						InstancesPerZone: 2,
+						InstancesPerZone: 3,
 						DriveCount:       1,
 						IOPS:             500,
 					},
@@ -325,10 +325,37 @@ func storageDistribution(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			// Test10: Install with lower sized disks
+			request: &cloudops.StorageDistributionRequest{
+				UserStorageSpec: []*cloudops.StorageSpec{
+					&cloudops.StorageSpec{
+						IOPS:        300,
+						MinCapacity: 150,
+						MaxCapacity: 300,
+					},
+				},
+				InstanceType:     "foo",
+				InstancesPerZone: 1,
+				ZoneCount:        3,
+			},
+			response: &cloudops.StorageDistributionResponse{
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 64,
+						DriveType:        "Standard_LRS",
+						InstancesPerZone: 1,
+						DriveCount:       1,
+						IOPS:             500,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
 	}
 
-	for i, test := range testMatrix {
-		fmt.Println("Executing test case: ", i)
+	for j, test := range testMatrix {
+		fmt.Println("Executing test case: ", j+1)
 		response, err := storageManager.GetStorageDistribution(test.request)
 		if test.expectedErr == nil {
 			require.NoError(t, err, "Unexpected error on GetStorageDistribution")
@@ -336,7 +363,7 @@ func storageDistribution(t *testing.T) {
 			require.Equal(t, len(test.response.InstanceStorage), len(response.InstanceStorage), "unequal response lengths")
 			for i := range test.response.InstanceStorage {
 				require.True(t, reflect.DeepEqual(*response.InstanceStorage[i], *test.response.InstanceStorage[i]),
-					"Expected Response: %+v . Actual Response %+v",
+					"Test Case %v Expected Response: %+v . Actual Response %+v", j+1,
 					test.response.InstanceStorage[i], response.InstanceStorage[i])
 			}
 		} else {
@@ -555,6 +582,30 @@ func storageUpdate(t *testing.T) {
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 280,
 						DriveType:        "Standard_LRS",
+						DriveCount:       1,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 10 -> lower sized disks
+			//        Instance has 1 x 200 GiB
+			//        Update from 200GiB to 400 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     400,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				CurrentDriveSize:    200,
+				CurrentDriveType:    "Premium_LRS",
+				CurrentDriveCount:   1,
+				TotalDrivesOnNode:   1,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 200,
+						DriveType:        "Premium_LRS",
 						DriveCount:       1,
 					},
 				},

--- a/azure/storagemanager/testspecs/azure-storage-decision-matrix.yaml
+++ b/azure/storagemanager/testspecs/azure-storage-decision-matrix.yaml
@@ -1,4 +1,34 @@
 rows:
+        - iops: 120
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32
+          max_size: 64
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 240
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 64
+          max_size: 128
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 128
+          max_size: 256
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
         - iops: 1100
           instance_type: "*"
           instance_max_drives: 8
@@ -49,6 +79,36 @@ rows:
           priority: 2
           thin_provisioning: false
           drive_type: "Premium_LRS"
+        - iops: 120
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32
+          max_size: 64
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 240
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 64
+          max_size: 128
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 128
+          max_size: 4096
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
         - iops: 500
           instance_type: "*"
           instance_max_drives: 8
@@ -84,7 +144,7 @@ rows:
           instance_max_drives: 8
           instance_min_drives: 1
           region: "*"
-          min_size: 256
+          min_size: 64
           max_size: 4096
           priority: 0
           thin_provisioning: false

--- a/pkg/storagedistribution/storagedistribution.go
+++ b/pkg/storagedistribution/storagedistribution.go
@@ -293,18 +293,17 @@ func getStorageDistributionCandidateForPool(
 	var (
 		capacityPerNode, instancesPerZone, driveCount, driveSize uint64
 		row                                                      cloudops.StorageDecisionMatrixRow
-		rowIndex                                                 int
+		rowIndex                                                 uint64
 	)
 
 row_loop:
-	for rowIndex := uint64(0); rowIndex < uint64(len(dm.Rows)); rowIndex++ {
+	for rowIndex = uint64(0); rowIndex < uint64(len(dm.Rows)); rowIndex++ {
 		row = dm.Rows[rowIndex]
 		// Favour maximum instances per zone
 	instances_per_zone_loop:
 		for instancesPerZone = requestedInstancesPerZone; instancesPerZone > 0; instancesPerZone-- {
 			capacityPerNode = minCapacityPerZone / uint64(instancesPerZone)
 			printCandidates("Candidate", []cloudops.StorageDecisionMatrixRow{row}, instancesPerZone, capacityPerNode)
-
 			// Favour maximum drive count
 			// drive_count_loop:
 			foundCandidate := false
@@ -347,7 +346,7 @@ row_loop:
 		break row_loop
 	}
 
-	if rowIndex == len(dm.Rows) {
+	if int(rowIndex) == len(dm.Rows) {
 		// row_loop failed
 		return nil, 0, cloudops.ErrStorageDistributionCandidateNotFound
 	}

--- a/specs/decisionmatrix/azure.yaml
+++ b/specs/decisionmatrix/azure.yaml
@@ -1,4 +1,34 @@
 rows:
+        - iops: 120
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32
+          max_size: 64
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 240
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 64
+          max_size: 128
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 128
+          max_size: 256
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
         - iops: 1100
           instance_type: "*"
           instance_max_drives: 8
@@ -49,6 +79,36 @@ rows:
           priority: 2
           thin_provisioning: false
           drive_type: "Premium_LRS"
+        - iops: 120
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32
+          max_size: 64
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 240
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 64
+          max_size: 128
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 128
+          max_size: 4096
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
         - iops: 500
           instance_type: "*"
           instance_max_drives: 8
@@ -84,7 +144,7 @@ rows:
           instance_max_drives: 8
           instance_min_drives: 1
           region: "*"
-          min_size: 256
+          min_size: 64
           max_size: 4096
           priority: 0
           thin_provisioning: false


### PR DESCRIPTION
- Added UTs for Azure GetStorageUpdate API
Add more rows for smaller sized disks in azure decision matrix. 
- The azure yaml did not have rows for smaller disk sizes in all its 3 types.
- Had to modify a few UTs as the responses changed after adding smaller sized disks.