### PR TITLE
return specific error if desired capacity is already greater than current

### DIFF
--- a/azure/storagemanager/azure_test.go
+++ b/azure/storagemanager/azure_test.go
@@ -612,6 +612,48 @@ func storageUpdate(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			// ***** TEST: 11 -> ask for one more GiB
+			//        Instance has 2 x 200 GiB
+			//        Update from 400 GiB to 401 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     401,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				CurrentDriveSize:    200,
+				CurrentDriveType:    "Premium_LRS",
+				CurrentDriveCount:   2,
+				TotalDrivesOnNode:   2,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage: []*cloudops.StoragePoolSpec{
+					&cloudops.StoragePoolSpec{
+						DriveCapacityGiB: 200,
+						DriveType:        "Premium_LRS",
+						DriveCount:       1,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			// ***** TEST: 12 instance is already at higher capacity than requested
+			//        Instance has 3 x 200 GiB
+			//        Update from 600 GiB to 401 GiB by adding disks
+			request: &cloudops.StoragePoolUpdateRequest{
+				DesiredCapacity:     401,
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				CurrentDriveSize:    200,
+				CurrentDriveType:    "Premium_LRS",
+				CurrentDriveCount:   3,
+				TotalDrivesOnNode:   3,
+			},
+			response: &cloudops.StoragePoolUpdateResponse{
+				ResizeOperationType: api.SdkStoragePool_RESIZE_TYPE_ADD_DISK,
+				InstanceStorage:     nil,
+			},
+			expectedErr: &cloudops.ErrCurrentCapacityHigherThanDesired{Current: 600, Desired: 401},
+		},
 	}
 
 	for i, test := range testMatrix {
@@ -643,7 +685,7 @@ func storageUpdate(t *testing.T) {
 			}
 		} else {
 			require.NotNil(t, err, "RecommendInstanceStorageUpdate should have returned an error")
-			require.Equal(t, test.expectedErr, err, "received unexpected type of error")
+			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
 		}
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -87,3 +87,16 @@ func (e *ErrInvalidStoragePoolUpdateRequest) Error() string {
 	return fmt.Sprintf("Invalid request to update storage on instance due to: %s Request: %v",
 		e.Reason, e.Request)
 }
+
+// ErrCurrentCapacityHigherThanDesired is returned when the current capacity of the instance is already higher than
+// the desired capacity
+type ErrCurrentCapacityHigherThanDesired struct {
+	// Current is the current capacity
+	Current uint64
+	// Desired is the desired new capacity
+	Desired uint64
+}
+
+func (e *ErrCurrentCapacityHigherThanDesired) Error() string {
+	return fmt.Sprintf("current capacity (%d) is higher than desired capacity: %d", e.Current, e.Desired)
+}

--- a/pkg/storagedistribution/storagedistribution.go
+++ b/pkg/storagedistribution/storagedistribution.go
@@ -377,16 +377,14 @@ func validateUpdateRequest(
 	request *cloudops.StoragePoolUpdateRequest,
 ) error {
 	currentCapacity := request.CurrentDriveCount * request.CurrentDriveSize
-	newDeltaCapacity := request.DesiredCapacity - currentCapacity
-
-	if newDeltaCapacity < 0 {
-		return &cloudops.ErrInvalidStoragePoolUpdateRequest{
-			Request: request,
-			Reason: fmt.Sprintf("reducing instance storage capacity is not supported"+
-				"current: %d GiB requested: %d GiB", currentCapacity, request.DesiredCapacity),
+	if currentCapacity > request.DesiredCapacity {
+		return &cloudops.ErrCurrentCapacityHigherThanDesired{
+			Current: currentCapacity,
+			Desired: request.DesiredCapacity,
 		}
 	}
 
+	newDeltaCapacity := request.DesiredCapacity - currentCapacity
 	if newDeltaCapacity == 0 {
 		return cloudops.ErrCurrentCapacitySameAsDesired
 	}


### PR DESCRIPTION
cloudops will return this specific error if current capacity is already higher than required.

This allows PX to handle this as a non-failure.

Also previous the below code was buggy. `newDeltaCapacity` was not getting less than zero due to incorrect int types: newDeltaCapacity

```
newDeltaCapacity := request.DesiredCapacity - currentCapacity
if newDeltaCapacity < 0 {
```

Signed-off-by: Harsh Desai <harsh@portworx.com>