### PR TITLE
Create azure clients using baseURI

### DIFF
--- a/azure/base_vmsclient.go
+++ b/azure/base_vmsclient.go
@@ -14,15 +14,15 @@ type baseVMsClient struct {
 }
 
 func newBaseVMsClient(
-	subscriptionID, resourceGroupName string,
+	config Config,
 	authorizer autorest.Authorizer,
 ) vmsClient {
-	vmsClient := compute.NewVirtualMachinesClient(subscriptionID)
+	vmsClient := compute.NewVirtualMachinesClient(config.SubscriptionID)
 	vmsClient.Authorizer = authorizer
 	vmsClient.PollingDelay = clientPollingDelay
-	vmsClient.AddToUserAgent(userAgentExtension)
+	vmsClient.AddToUserAgent(config.UserAgent)
 	return &baseVMsClient{
-		resourceGroupName: resourceGroupName,
+		resourceGroupName: config.ResourceGroupName,
 		client:            &vmsClient,
 	}
 }

--- a/azure/base_vmsclient.go
+++ b/azure/base_vmsclient.go
@@ -15,9 +15,10 @@ type baseVMsClient struct {
 
 func newBaseVMsClient(
 	config Config,
+	baseURI string,
 	authorizer autorest.Authorizer,
 ) vmsClient {
-	vmsClient := compute.NewVirtualMachinesClient(config.SubscriptionID)
+	vmsClient := compute.NewVirtualMachinesClientWithBaseURI(baseURI, config.SubscriptionID)
 	vmsClient.Authorizer = authorizer
 	vmsClient.PollingDelay = clientPollingDelay
 	vmsClient.AddToUserAgent(config.UserAgent)

--- a/azure/scaleset_vmsclient.go
+++ b/azure/scaleset_vmsclient.go
@@ -16,9 +16,10 @@ type scaleSetVMsClient struct {
 
 func newScaleSetVMsClient(
 	config Config,
+	baseURI string,
 	authorizer autorest.Authorizer,
 ) vmsClient {
-	vmsClient := compute.NewVirtualMachineScaleSetVMsClient(config.SubscriptionID)
+	vmsClient := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(baseURI, config.SubscriptionID)
 	vmsClient.Authorizer = authorizer
 	vmsClient.PollingDelay = clientPollingDelay
 	vmsClient.AddToUserAgent(config.UserAgent)

--- a/azure/scaleset_vmsclient.go
+++ b/azure/scaleset_vmsclient.go
@@ -15,16 +15,16 @@ type scaleSetVMsClient struct {
 }
 
 func newScaleSetVMsClient(
-	scaleSetName, subscriptionID, resourceGroupName string,
+	config Config,
 	authorizer autorest.Authorizer,
 ) vmsClient {
-	vmsClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
+	vmsClient := compute.NewVirtualMachineScaleSetVMsClient(config.SubscriptionID)
 	vmsClient.Authorizer = authorizer
 	vmsClient.PollingDelay = clientPollingDelay
-	vmsClient.AddToUserAgent(userAgentExtension)
+	vmsClient.AddToUserAgent(config.UserAgent)
 	return &scaleSetVMsClient{
-		scaleSetName:      scaleSetName,
-		resourceGroupName: resourceGroupName,
+		scaleSetName:      config.ScaleSetName,
+		resourceGroupName: config.ResourceGroupName,
 		client:            &vmsClient,
 	}
 }

--- a/azure/vmsclient.go
+++ b/azure/vmsclient.go
@@ -18,21 +18,11 @@ type vmsClient interface {
 }
 
 func newVMsClient(
-	scaleSetName string,
-	subscriptionID, resourceGroupName string,
+	config Config,
 	authorizer autorest.Authorizer,
 ) vmsClient {
-	if scaleSetName == "" {
-		return newBaseVMsClient(
-			subscriptionID,
-			resourceGroupName,
-			authorizer,
-		)
+	if config.ScaleSetName == "" {
+		return newBaseVMsClient(config, authorizer)
 	}
-	return newScaleSetVMsClient(
-		scaleSetName,
-		subscriptionID,
-		resourceGroupName,
-		authorizer,
-	)
+	return newScaleSetVMsClient(config, authorizer)
 }

--- a/azure/vmsclient.go
+++ b/azure/vmsclient.go
@@ -19,10 +19,11 @@ type vmsClient interface {
 
 func newVMsClient(
 	config Config,
+	baseURI string,
 	authorizer autorest.Authorizer,
 ) vmsClient {
 	if config.ScaleSetName == "" {
-		return newBaseVMsClient(config, authorizer)
+		return newBaseVMsClient(config, baseURI, authorizer)
 	}
-	return newScaleSetVMsClient(config, authorizer)
+	return newScaleSetVMsClient(config, baseURI, authorizer)
 }


### PR DESCRIPTION
- To support azure clouds like USGovernment, China, Germany clouds, azure sdk expects the clients to pass the management base URI when creating clients.
- Creating a new config object to be passed to NewClient as it is taking lot of args already.
- Changed NewClientFromMetadata to query only compute metadata