### PR TITLE
Add drive attach options to cloudOps Attach() api

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -770,7 +770,7 @@ func (s *awsOps) Delete(id string) error {
 	return err
 }
 
-func (s *awsOps) Attach(volumeID string) (string, error) {
+func (s *awsOps) Attach(volumeID string, options map[string]string) (string, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -442,7 +442,7 @@ func (a *azureOps) GetDeviceID(disk interface{}) (string, error) {
 	)
 }
 
-func (a *azureOps) Attach(diskName string) (string, error) {
+func (a *azureOps) Attach(diskName string, options map[string]string) (string, error) {
 	disk, err := a.checkDiskAttachmentStatus(diskName)
 	if err == nil {
 		// Disk is already attached locally, return device path

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -183,13 +183,13 @@ func (e *exponentialBackoff) GetDeviceID(template interface{}) (string, error) {
 
 // Attach volumeID.
 // Return attach path.
-func (e *exponentialBackoff) Attach(volumeID string) (string, error) {
+func (e *exponentialBackoff) Attach(volumeID string, options map[string]string) (string, error) {
 	var (
 		devPath string
 		origErr error
 	)
 	conditionFn := func() (bool, error) {
-		devPath, origErr = e.cloudOps.Attach(volumeID)
+		devPath, origErr = e.cloudOps.Attach(volumeID, options)
 		msg := fmt.Sprintf("Failed to attach drive (%v).", volumeID)
 		return e.handleError(origErr, msg)
 	}

--- a/cloudops.go
+++ b/cloudops.go
@@ -89,9 +89,9 @@ type Storage interface {
 	Create(template interface{}, labels map[string]string) (interface{}, error)
 	// GetDeviceID returns ID/Name of the given device/disk or snapshot
 	GetDeviceID(template interface{}) (string, error)
-	// Attach volumeID.
+	// Attach volumeID, accepts attachoOptions as opaque data
 	// Return attach path.
-	Attach(volumeID string) (string, error)
+	Attach(volumeID string, options map[string]string) (string, error)
 	// Expand expands the provided device from the existing size to the new size
 	// It returns the new size of the device. It is a blocking API where it will
 	// only return once the requested size is validated with the cloud provider or

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -296,7 +296,7 @@ func (s *gceOps) ApplyTags(
 	return s.waitForOpCompletion("disk.ApplyTags", s.inst.zone, operation)
 }
 
-func (s *gceOps) Attach(diskName string) (string, error) {
+func (s *gceOps) Attach(diskName string, options map[string]string) (string, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/test/cloudops.go
+++ b/test/cloudops.go
@@ -268,7 +268,7 @@ func expand(t *testing.T, driver cloudops.Ops, diskName string, sizeCheck SizeCh
 }
 
 func attach(t *testing.T, driver cloudops.Ops, diskName string) {
-	devPath, err := driver.Attach(diskName)
+	devPath, err := driver.Attach(diskName, nil)
 	if err != nil && canErrBeIgnored(err) {
 		// don't check devPath
 	} else {
@@ -289,7 +289,7 @@ func attach(t *testing.T, driver cloudops.Ops, diskName string) {
 
 	time.Sleep(3 * time.Second)
 
-	devPath, err = driver.Attach(diskName)
+	devPath, err = driver.Attach(diskName, nil)
 	if err != nil && canErrBeIgnored(err) {
 		// don't check devPath
 	} else {

--- a/vsphere/lib/vsphere/vclib/virtualmachine.go
+++ b/vsphere/lib/vsphere/vclib/virtualmachine.go
@@ -305,8 +305,8 @@ func (vm *VirtualMachine) CreateDiskSpec(ctx context.Context, diskPath string, d
 	*disk.UnitNumber = unitNumber
 	backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
 	backing.DiskMode = string(types.VirtualDiskModeIndependent_persistent)
-	if volumeOptions.DiskType != "" {
-		backing.DiskMode = volumeOptions.DiskType
+	if volumeOptions.DiskMode != "" {
+		backing.DiskMode = volumeOptions.DiskMode
 	}
 	if volumeOptions.CapacityKB != 0 {
 		disk.CapacityInKB = int64(volumeOptions.CapacityKB)

--- a/vsphere/lib/vsphere/vclib/volumeoptions.go
+++ b/vsphere/lib/vsphere/vclib/volumeoptions.go
@@ -34,7 +34,7 @@ type VolumeOptions struct {
 	StoragePolicyID        string
 	SCSIControllerType     string
 	Zone                   []string
-	DiskType               string
+	DiskMode               string
 }
 
 var (


### PR DESCRIPTION
 For vsphere -
 - pass in disk attach type to vsphere vmdk attach api


Note: Base vendor PR has to be merged first -> https://github.com/libopenstorage/cloudops/pull/59