### PR TITLE
For first class disks, use disk type provided by the user

### DIFF
--- a/vsphere/lib/vsphere/vclib/constants.go
+++ b/vsphere/lib/vsphere/vclib/constants.go
@@ -22,6 +22,7 @@ const (
 	PreallocatedDiskType     = "preallocated"
 	EagerZeroedThickDiskType = "eagerZeroedThick"
 	ZeroedThickDiskType      = "zeroedThick"
+	LazyZeroedThickDiskType  = "lazyZeroedThick"
 )
 
 // Controller Constants

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -171,6 +171,20 @@ func (ops *vsphereOps) Create(opts interface{}, labels map[string]string) (inter
 	if apiVersion.GreaterThan(keepDiskVersion) || apiVersion.Equal(keepDiskVersion) {
 		// create disk using the new API so it doesn't get deleted after VM deletion
 		m := vslm.NewObjectManager(vmObj.Client())
+		var provisioningType string
+		switch volumeOptions.DiskFormat {
+		case vclib.LazyZeroedThickDiskType:
+			provisioningType = string(types.BaseConfigInfoDiskFileBackingInfoProvisioningTypeLazyZeroedThick)
+		case vclib.ThinDiskType:
+			provisioningType = string(types.BaseConfigInfoDiskFileBackingInfoProvisioningTypeThin)
+		case vclib.ZeroedThickDiskType:
+			fallthrough
+		case vclib.EagerZeroedThickDiskType:
+			fallthrough
+		default:
+			provisioningType = string(types.BaseConfigInfoDiskFileBackingInfoProvisioningTypeEagerZeroedThick)
+		}
+
 		spec := types.VslmCreateSpec{
 			Name:              volumeOptions.Name,
 			CapacityInMB:      int64(volumeOptions.CapacityKB*1024) / units.MB,
@@ -179,7 +193,7 @@ func (ops *vsphereOps) Create(opts interface{}, labels map[string]string) (inter
 				VslmCreateSpecBackingSpec: types.VslmCreateSpecBackingSpec{
 					Datastore: ds.Reference(),
 				},
-				ProvisioningType: string(types.BaseConfigInfoDiskFileBackingInfoProvisioningTypeThin),
+				ProvisioningType: provisioningType,
 			},
 		}
 

--- a/vsphere/vsphere_test.go
+++ b/vsphere/vsphere_test.go
@@ -40,6 +40,7 @@ func initVsphere(t *testing.T) (cloudops.Ops, map[string]interface{}) {
 		Name:       diskName,
 		CapacityKB: newDiskSizeInKB,
 		Datastore:  datastoreForTest,
+		DiskFormat: vclib.EagerZeroedThickDiskType,
 	}
 
 	return driver, map[string]interface{}{


### PR DESCRIPTION
For vSphere 6.7 and above, we now create first class disks (FCD). In this mode, we are ignoring the user-provided disk type and defaulting to thin.

Signed-off-by: Harsh Desai <harsh@portworx.com>