### PR TITLE
Update only concerned fields during VM update

### DIFF
--- a/azure/scaleset_vmsclient.go
+++ b/azure/scaleset_vmsclient.go
@@ -64,7 +64,11 @@ func (s *scaleSetVMsClient) updateDataDisks(
 		return err
 	}
 
-	vm.StorageProfile.DataDisks = &dataDisks
+	vm.VirtualMachineScaleSetVMProperties = &compute.VirtualMachineScaleSetVMProperties{
+		StorageProfile: &compute.StorageProfile{
+			DataDisks: &dataDisks,
+		},
+	}
 
 	ctx := context.Background()
 	future, err := s.client.Update(


### PR DESCRIPTION
- VMSS VM update call takes the complete VM object, but that we
  still need to pass only the change we desire (at least in the
  VM properties section).
  As we were sending the existing object as is, we used to get
  server errors for fields that were not concerned to us.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>