### PR TITLE
Fix GCE min and max values for instance group

### DIFF
--- a/gce/gce.go
+++ b/gce/gce.go
@@ -249,9 +249,13 @@ func (s *gceOps) InspectInstanceGroupForInstance(instanceID string) (*cloudops.I
 			}
 
 			if nodePool.Autoscaling != nil {
+				// to get actual min and max count, need to multiple total number of zones with the count
+				// for e.g if MinNodeCount = 1 and we have 3 zones, there will be a minimum of 3 nodes, 1 per zone.
+				minCount := nodePool.Autoscaling.MinNodeCount * int64(len(retval.Zones))
+				maxCount := nodePool.Autoscaling.MaxNodeCount * int64(len(retval.Zones))
 				retval.AutoscalingEnabled = nodePool.Autoscaling.Enabled
-				retval.Min = &nodePool.Autoscaling.MinNodeCount
-				retval.Max = &nodePool.Autoscaling.MaxNodeCount
+				retval.Min = &minCount
+				retval.Max = &maxCount
 			}
 
 			if nodePool.Config != nil {


### PR DESCRIPTION
- The min and max values for a node pool in GKE need to factor in the total number of zones. This is needed
so that the value returned conforms to the value returned by other clouds (e.g AWS).

The current cloudops API expects the min and max values in the instance group to be across the zones. As a result, the usage in porx divides the value by the number of zones to get the per zone value.

Signed-off-by: Harsh Desai <harsh@portworx.com>