### PR TITLE
azure: add a check for nil vm scale set properties

### DIFF
--- a/azure/scaleset_vmsclient.go
+++ b/azure/scaleset_vmsclient.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/go-autorest/autorest"
@@ -48,11 +47,7 @@ func (s *scaleSetVMsClient) getDataDisks(
 		return nil, err
 	}
 
-	if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
-		return nil, fmt.Errorf("vm storage profile is invalid")
-	}
-
-	return *vm.StorageProfile.DataDisks, nil
+	return retrieveDataDisks(vm), nil
 }
 
 func (s *scaleSetVMsClient) updateDataDisks(
@@ -99,4 +94,15 @@ func (s *scaleSetVMsClient) describeInstance(
 		instanceID,
 		compute.InstanceView,
 	)
+}
+
+func retrieveDataDisks(vm compute.VirtualMachineScaleSetVM) []compute.DataDisk {
+	if vm.VirtualMachineScaleSetVMProperties == nil ||
+		vm.VirtualMachineScaleSetVMProperties.StorageProfile == nil ||
+		vm.VirtualMachineScaleSetVMProperties.StorageProfile.DataDisks == nil ||
+		*vm.VirtualMachineScaleSetVMProperties.StorageProfile.DataDisks == nil {
+		return []compute.DataDisk{}
+	}
+
+	return *vm.StorageProfile.DataDisks
 }

--- a/azure/scaleset_vmsclient_test.go
+++ b/azure/scaleset_vmsclient_test.go
@@ -1,0 +1,87 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrieveDataDisks(t *testing.T) {
+	var nilDiskSlice []compute.DataDisk
+	testDisks := []compute.DataDisk{
+		{
+			Name: to.StringPtr("disk1"),
+		},
+		{
+			Name: to.StringPtr("disk2"),
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		input       compute.VirtualMachineScaleSetVM
+		expectedRes []compute.DataDisk
+	}{
+		{
+			name:  "nil vm properties",
+			input: compute.VirtualMachineScaleSetVM{},
+			expectedRes: []compute.DataDisk{},
+		},
+		{
+			name: "nil storage profile",
+			input: compute.VirtualMachineScaleSetVM{
+				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{},
+			},
+			expectedRes: []compute.DataDisk{},
+		},
+		{
+			name: "nil data disks reference",
+			input: compute.VirtualMachineScaleSetVM{
+				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+					StorageProfile: &compute.StorageProfile{},
+				},
+			},
+			expectedRes: []compute.DataDisk{},
+		},
+		{
+			name: "nil data disks slice",
+			input: compute.VirtualMachineScaleSetVM{
+				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+					StorageProfile: &compute.StorageProfile{
+						DataDisks: &nilDiskSlice,
+					},
+				},
+			},
+			expectedRes: []compute.DataDisk{},
+		},
+		{
+			name: "empty data disks slice",
+			input: compute.VirtualMachineScaleSetVM{
+				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+					StorageProfile: &compute.StorageProfile{
+						DataDisks: &([]compute.DataDisk{}),
+					},
+				},
+			},
+			expectedRes: []compute.DataDisk{},
+		},
+		{
+			name: "test data disks",
+			input: compute.VirtualMachineScaleSetVM{
+				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+					StorageProfile: &compute.StorageProfile{
+						DataDisks: &testDisks,
+					},
+				},
+			},
+			expectedRes: testDisks,
+		},
+	}
+
+	for _, tc := range testCases {
+		res := retrieveDataDisks(tc.input)
+		require.Equalf(t, tc.expectedRes, res, "TC: %s", tc.name)
+	}
+}


### PR DESCRIPTION
Fix a panic while accessing the vm scale set StorageProfile with empty vm properties. Details - PWX-17554

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>