### PR TITLE
PWX-19318 Don't add empty outpost ARN to create request

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -713,7 +713,6 @@ func (s *awsOps) Create(
 			"Invalid volume template given", "")
 	}
 
-	outpostARN := s.outpostARN
 	req := &ec2.CreateVolumeInput{
 		AvailabilityZone: vol.AvailabilityZone,
 		Encrypted:        vol.Encrypted,
@@ -721,7 +720,11 @@ func (s *awsOps) Create(
 		Size:             vol.Size,
 		VolumeType:       vol.VolumeType,
 		SnapshotId:       vol.SnapshotId,
-		OutpostArn:       &outpostARN,
+	}
+
+	if len(s.outpostARN) > 0 {
+		outpostARN := s.outpostARN
+		req.OutpostArn = &outpostARN
 	}
 
 	if len(vol.Tags) > 0 || len(labels) > 0 {


### PR DESCRIPTION
Signed-off-by: Harsh Desai <hadesai@purestorage.com>


**What this PR does / why we need it**:

Empty outpost ARN in create request was breaking non-outpost clusters


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

