### PR TITLE
[PTX-2162] Specify OSType while setting instance group size for Azure

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -347,6 +347,7 @@ func (a *azureOps) SetInstanceGroupSize(instanceGroupID string,
 	instanceGroupSize := int32(count)
 	agentPoolProperties := containerservice.ManagedClusterAgentPoolProfileProperties{
 		Count: &instanceGroupSize,
+		OsType: containerservice.Linux,
 	}
 
 	agentPool := containerservice.AgentPool{


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR mentions the OSType of AKS node group while updating it. 

Without this fix updating of instance group size on AKS fails with below error:
```
failed to set size of node pool nodepool1. Error: Failed to set size for node group [nodepool1] of managed cluster [torpedo-tp-aks].Error:[containerservice.AgentPoolsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="SystemPoolMustBeLinux" Message="System node pool must be linux. Nodepool name: nodepool1."] 
```
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

