### PR TITLE
Updates Pure matrix to allow up to 32 drives per instance, and changes the Pure drive type to pure-block

### DIFF
--- a/specs/decisionmatrix/pure.yaml
+++ b/specs/decisionmatrix/pure.yaml
@@ -1,7 +1,7 @@
 rows:
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 32
     max_size: 100
@@ -9,7 +9,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 100
     max_size: 500
@@ -17,7 +17,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 500
     max_size: 1024
@@ -25,7 +25,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 1024
     max_size: 2048
@@ -33,7 +33,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 2048
     max_size: 4096
@@ -41,7 +41,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 4096
     max_size: 8192
@@ -49,7 +49,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 8192
     max_size: 16384
@@ -57,7 +57,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 16384
     max_size: 32768
@@ -65,7 +65,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 32768
     max_size: 65536
@@ -73,7 +73,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 65536
     max_size: 131072
@@ -81,7 +81,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 131072
     max_size: 262144
@@ -89,7 +89,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 262144
     max_size: 524288
@@ -97,7 +97,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 524288
     max_size: 1048576
@@ -105,7 +105,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 1048576
     max_size: 2097152
@@ -113,7 +113,7 @@ rows:
     drive_type: "pure"
   - instance_type: "*"
     instance_min_drives: 1
-    instance_max_drives: 12
+    instance_max_drives: 32
     region: "*"
     min_size: 2097152
     max_size: 4194304

--- a/specs/decisionmatrix/pure.yaml
+++ b/specs/decisionmatrix/pure.yaml
@@ -6,7 +6,7 @@ rows:
     min_size: 32
     max_size: 100
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -14,7 +14,7 @@ rows:
     min_size: 100
     max_size: 500
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -22,7 +22,7 @@ rows:
     min_size: 500
     max_size: 1024
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -30,7 +30,7 @@ rows:
     min_size: 1024
     max_size: 2048
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -38,7 +38,7 @@ rows:
     min_size: 2048
     max_size: 4096
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -46,7 +46,7 @@ rows:
     min_size: 4096
     max_size: 8192
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -54,7 +54,7 @@ rows:
     min_size: 8192
     max_size: 16384
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -62,7 +62,7 @@ rows:
     min_size: 16384
     max_size: 32768
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -70,7 +70,7 @@ rows:
     min_size: 32768
     max_size: 65536
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -78,7 +78,7 @@ rows:
     min_size: 65536
     max_size: 131072
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -86,7 +86,7 @@ rows:
     min_size: 131072
     max_size: 262144
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -94,7 +94,7 @@ rows:
     min_size: 262144
     max_size: 524288
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -102,7 +102,7 @@ rows:
     min_size: 524288
     max_size: 1048576
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -110,7 +110,7 @@ rows:
     min_size: 1048576
     max_size: 2097152
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"
   - instance_type: "*"
     instance_min_drives: 1
     instance_max_drives: 32
@@ -118,4 +118,4 @@ rows:
     min_size: 2097152
     max_size: 4194304
     priority: 0
-    drive_type: "pure"
+    drive_type: "pure-block"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently the Pure decision matrix only allows up to 12 drives, but we support up to (at least) 255 volumes connected at a time. This updates the matrix to reflect this.

**Special notes for your reviewer**:

