### PR TITLE
PWX-20131: Increase soft-limit on disk size to 32TiB on Azure

### DIFF
--- a/azure/storagemanager/azure_test.go
+++ b/azure/storagemanager/azure_test.go
@@ -115,7 +115,7 @@ func storageDistribution(t *testing.T) {
 					&cloudops.StorageSpec{
 						IOPS:        5000,
 						MinCapacity: 9216,
-						MaxCapacity: 100000,
+						MaxCapacity: 90000,
 					},
 				},
 				InstanceType:     "foo",
@@ -260,7 +260,7 @@ func storageDistribution(t *testing.T) {
 					&cloudops.StorageSpec{
 						IOPS:        5000,
 						MinCapacity: 9216,
-						MaxCapacity: 100000,
+						MaxCapacity: 90000,
 					},
 				},
 				InstanceType:     "foo",
@@ -742,7 +742,7 @@ func storageUpdate(t *testing.T) {
 			expectedErr: &cloudops.ErrStorageDistributionCandidateNotFound{
 				Reason: "found no candidates for adding a new disk of existing size: 5 GiB. Only drives in following " +
 					"size ranges are supported: [[1024 GiB -> 8192 GiB (Premium_LRS)] [128 GiB -> 256 GiB (Premium_LRS)]" +
-					" [2048 GiB -> 8192 GiB (Premium_LRS)] [256 GiB -> 8192 GiB (Premium_LRS)] [32 GiB -> 64 GiB (Premium_LRS)] [512 GiB -> 8192 GiB (Premium_LRS)] [64 GiB -> 128 GiB (Premium_LRS)] [8192 GiB -> 8192 GiB (Premium_LRS)]]",
+					" [16384 GiB -> 32768 GiB (Premium_LRS)] [2048 GiB -> 8192 GiB (Premium_LRS)] [256 GiB -> 8192 GiB (Premium_LRS)] [32 GiB -> 64 GiB (Premium_LRS)] [32768 GiB -> 32768 GiB (Premium_LRS)] [512 GiB -> 8192 GiB (Premium_LRS)] [64 GiB -> 128 GiB (Premium_LRS)] [8192 GiB -> 16384 GiB (Premium_LRS)]]",
 			},
 		},
 	}

--- a/azure/storagemanager/testspecs/azure-storage-decision-matrix.yaml
+++ b/azure/storagemanager/testspecs/azure-storage-decision-matrix.yaml
@@ -83,7 +83,29 @@ rows:
           instance_min_drives: 1
           region: "*"
           min_size: 8192
-          max_size: 8192
+          max_size: 16384
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - min_iops: 18000
+          max_iops: 18000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 16384
+          max_size: 32768
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - min_iops: 20000
+          max_iops: 20000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32768
+          max_size: 32768
           priority: 2
           thin_provisioning: false
           drive_type: "Premium_LRS"
@@ -153,6 +175,17 @@ rows:
           priority: 1
           thin_provisioning: false
           drive_type: "StandardSSD_LRS"
+        - min_iops: 6000
+          max_iops: 6000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32768
+          max_size: 32768
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
         - min_iops: 500
           max_iops: 500
           instance_type: "*"
@@ -182,7 +215,7 @@ rows:
           instance_min_drives: 1
           region: "*"
           min_size: 16384
-          max_size: 16384
+          max_size: 32768
           priority: 3
           thin_provisioning: false
           drive_type: "Standard_LRS"

--- a/specs/decisionmatrix/azure.yaml
+++ b/specs/decisionmatrix/azure.yaml
@@ -83,7 +83,29 @@ rows:
           instance_min_drives: 1
           region: "*"
           min_size: 8192
-          max_size: 8192
+          max_size: 16384
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - min_iops: 18000
+          max_iops: 18000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 16384
+          max_size: 32768
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - min_iops: 20000
+          max_iops: 20000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32768
+          max_size: 32768
           priority: 2
           thin_provisioning: false
           drive_type: "Premium_LRS"
@@ -153,6 +175,17 @@ rows:
           priority: 1
           thin_provisioning: false
           drive_type: "StandardSSD_LRS"
+        - min_iops: 6000
+          max_iops: 6000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 32768
+          max_size: 32768
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
         - min_iops: 500
           max_iops: 500
           instance_type: "*"
@@ -182,7 +215,7 @@ rows:
           instance_min_drives: 1
           region: "*"
           min_size: 16384
-          max_size: 16384
+          max_size: 32768
           priority: 3
           thin_provisioning: false
           drive_type: "Standard_LRS"


### PR DESCRIPTION
   Azure has new disk sizes/types since the last time we updated our yaml.
   This patch those new disk sizes and types

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

