### PR TITLE
PWX-24534: Passing disk encryption key during cloud drive creation.

### DIFF
--- a/gce/gce.go
+++ b/gce/gce.go
@@ -379,14 +379,15 @@ func (s *gceOps) Create(
 	}
 
 	newDisk := &compute.Disk{
-		Description:    "Disk created by openstorage",
-		Labels:         formatLabels(labels),
-		Name:           v.Name,
-		SizeGb:         v.SizeGb,
-		SourceImage:    v.SourceImage,
-		SourceSnapshot: v.SourceSnapshot,
-		Type:           v.Type,
-		Zone:           path.Base(v.Zone),
+		Description:       "Disk created by openstorage",
+		Labels:            formatLabels(labels),
+		Name:              v.Name,
+		SizeGb:            v.SizeGb,
+		SourceImage:       v.SourceImage,
+		SourceSnapshot:    v.SourceSnapshot,
+		Type:              v.Type,
+		DiskEncryptionKey: v.DiskEncryptionKey,
+		Zone:              path.Base(v.Zone),
 	}
 
 	operation, err := s.computeService.Disks.Insert(s.inst.project, newDisk.Zone, newDisk).Do()


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cloud drive encryption required cloud drive encryption kms key to be passed  during the drive creation. Passing the DiskEncryptionKey as is passed by the caller of this function.

**Which issue(s) this PR fixes** (optional)
Closes #PWX-24534

**Special notes for your reviewer**:

