### PR TITLE
PWX-26307: Use default gce account when device level account not prov…

### DIFF
--- a/gce/gce.go
+++ b/gce/gce.go
@@ -2,6 +2,7 @@ package gce
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/parser"
 	"github.com/portworx/sched-ops/task"
 	"github.com/sirupsen/logrus"
+	google "golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
 	container "google.golang.org/api/container/v1"
 	"google.golang.org/api/googleapi"
@@ -63,6 +65,7 @@ type instance struct {
 	clusterName     string
 	clusterLocation string
 	nodePoolID      string
+	serviceAccount  string
 }
 
 // IsDevMode checks if the pkg is invoked in developer mode where GCE credentials
@@ -77,9 +80,10 @@ func IsDevMode() bool {
 func NewClient() (cloudops.Ops, error) {
 
 	var i = new(instance)
+	ctx := context.Background()
 	var err error
 	if metadata.OnGCE() {
-		err = gceInfo(i)
+		err = gceInfo(ctx, i)
 	} else if ok := IsDevMode(); ok {
 		err = gceInfoFromEnv(i)
 	} else {
@@ -90,7 +94,6 @@ func NewClient() (cloudops.Ops, error) {
 		return nil, fmt.Errorf("error fetching instance info. Err: %v", err)
 	}
 
-	ctx := context.Background()
 	computeService, err := compute.NewService(ctx, option.WithScopes(compute.ComputeScope))
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Compute service: %v", err)
@@ -376,6 +379,11 @@ func (s *gceOps) Create(
 	if !ok {
 		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
 			"Invalid volume template given", "")
+	}
+
+	if isDiskEncryptedWithDefaultAccount(v) {
+		logrus.Infof("Default service account to be used as disk encryption kms service account")
+		v.DiskEncryptionKey.KmsKeyServiceAccount = s.inst.serviceAccount
 	}
 
 	newDisk := &compute.Disk{
@@ -1173,7 +1181,7 @@ func (s *gceOps) describeinstance() (*compute.Instance, error) {
 }
 
 // gceInfo fetches the GCE instance metadata from the metadata server
-func gceInfo(inst *instance) error {
+func gceInfo(ctx context.Context, inst *instance) error {
 	var err error
 	inst.zone, err = metadata.Zone()
 	if err != nil {
@@ -1225,6 +1233,19 @@ func gceInfo(inst *instance) error {
 			}
 		}
 	}
+
+	credential, err := google.FindDefaultCredentials(ctx)
+	content := map[string]interface{}{}
+	json.Unmarshal(credential.JSON, &content)
+	if content["client_email"] != nil {
+		inst.serviceAccount = fmt.Sprintf("%s", content["client_email"])
+	} else {
+		serviceAccount, err := metadata.Email("")
+		if err != nil {
+			return fmt.Errorf("unable to get gce instance service account")
+		}
+		inst.serviceAccount = serviceAccount
+	}
 	return nil
 }
 
@@ -1250,6 +1271,7 @@ func gceInfoFromEnv(inst *instance) error {
 	inst.clusterName, _ = cloudops.GetEnvValueStrict("GKE_CLUSTER_NAME")
 	inst.clusterLocation, _ = cloudops.GetEnvValueStrict("GKE_CLUSTER_LOCATION")
 	inst.nodePoolID, _ = cloudops.GetEnvValueStrict("GKE_NODE_POOL")
+	inst.serviceAccount, _ = cloudops.GetEnvValueStrict("GKE_CLUSTER_SERVICE_ACCOUNT")
 
 	return nil
 }
@@ -1481,4 +1503,10 @@ func isZonalCluster(clusterLocation string) (bool, error) {
 	// Zone e.g. us-central1-a
 	zoneRegex := "[a-zA-z0-9]+-[a-zA-Z0-9]+-[a-zA-Z]"
 	return regexp.MatchString(zoneRegex, clusterLocation)
+}
+
+func isDiskEncryptedWithDefaultAccount(d *compute.Disk) bool {
+	return d.DiskEncryptionKey != nil &&
+		len(d.DiskEncryptionKey.KmsKeyName) > 0 &&
+		len(d.DiskEncryptionKey.KmsKeyServiceAccount) == 0
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/vmware/govmomi v0.22.2
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	google.golang.org/api v0.30.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -1591,6 +1591,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1604,8 +1605,9 @@ golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5 h1:Lm4OryKCca1vehdsWogr9N4t7NfZxLbJoc/H0w4K4S4=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/vendor/golang.org/x/oauth2/authhandler/authhandler.go
+++ b/vendor/golang.org/x/oauth2/authhandler/authhandler.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package authhandler implements a TokenSource to support
+// "three-legged OAuth 2.0" via a custom AuthorizationHandler.
+package authhandler
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/oauth2"
+)
+
+// AuthorizationHandler is a 3-legged-OAuth helper that prompts
+// the user for OAuth consent at the specified auth code URL
+// and returns an auth code and state upon approval.
+type AuthorizationHandler func(authCodeURL string) (code string, state string, err error)
+
+// TokenSource returns an oauth2.TokenSource that fetches access tokens
+// using 3-legged-OAuth flow.
+//
+// The provided context.Context is used for oauth2 Exchange operation.
+//
+// The provided oauth2.Config should be a full configuration containing AuthURL,
+// TokenURL, and Scope.
+//
+// An environment-specific AuthorizationHandler is used to obtain user consent.
+//
+// Per the OAuth protocol, a unique "state" string should be specified here.
+// This token source will verify that the "state" is identical in the request
+// and response before exchanging the auth code for OAuth token to prevent CSRF
+// attacks.
+func TokenSource(ctx context.Context, config *oauth2.Config, state string, authHandler AuthorizationHandler) oauth2.TokenSource {
+	return oauth2.ReuseTokenSource(nil, authHandlerSource{config: config, ctx: ctx, authHandler: authHandler, state: state})
+}
+
+type authHandlerSource struct {
+	ctx         context.Context
+	config      *oauth2.Config
+	authHandler AuthorizationHandler
+	state       string
+}
+
+func (source authHandlerSource) Token() (*oauth2.Token, error) {
+	url := source.config.AuthCodeURL(source.state)
+	code, state, err := source.authHandler(url)
+	if err != nil {
+		return nil, err
+	}
+	if state != source.state {
+		return nil, errors.New("state mismatch in 3-legged-OAuth flow")
+	}
+	return source.config.Exchange(source.ctx, code)
+}

--- a/vendor/golang.org/x/oauth2/go.mod
+++ b/vendor/golang.org/x/oauth2/go.mod
@@ -4,6 +4,6 @@ go 1.11
 
 require (
 	cloud.google.com/go v0.65.0
-	golang.org/x/net v0.0.0-20200822124328-c89045814202
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	google.golang.org/appengine v1.6.6
 )

--- a/vendor/golang.org/x/oauth2/go.sum
+++ b/vendor/golang.org/x/oauth2/go.sum
@@ -177,8 +177,9 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -217,11 +218,15 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/vendor/golang.org/x/oauth2/google/appengine_gen1.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen1.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 // This file applies to App Engine first generation runtimes (<= Go 1.9).

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !appengine
 // +build !appengine
 
 // This file applies to App Engine second generation runtimes (>= Go 1.11) and App Engine flexible.

--- a/vendor/golang.org/x/oauth2/google/default.go
+++ b/vendor/golang.org/x/oauth2/google/default.go
@@ -16,11 +16,16 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/authhandler"
 )
 
 // Credentials holds Google credentials, including "Application Default Credentials".
 // For more details, see:
 // https://developers.google.com/accounts/docs/application-default-credentials
+// Credentials from external accounts (workload identity federation) are used to
+// identify a particular application from an on-prem or non-Google Cloud platform
+// including Amazon Web Services (AWS), Microsoft Azure or any identity provider
+// that supports OpenID Connect (OIDC).
 type Credentials struct {
 	ProjectID   string // may be empty
 	TokenSource oauth2.TokenSource
@@ -36,6 +41,32 @@ type Credentials struct {
 //
 // Deprecated: use Credentials instead.
 type DefaultCredentials = Credentials
+
+// CredentialsParams holds user supplied parameters that are used together
+// with a credentials file for building a Credentials object.
+type CredentialsParams struct {
+	// Scopes is the list OAuth scopes. Required.
+	// Example: https://www.googleapis.com/auth/cloud-platform
+	Scopes []string
+
+	// Subject is the user email used for domain wide delegation (see
+	// https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority).
+	// Optional.
+	Subject string
+
+	// AuthHandler is the AuthorizationHandler used for 3-legged OAuth flow. Optional.
+	AuthHandler authhandler.AuthorizationHandler
+
+	// State is a unique string used with AuthHandler. Optional.
+	State string
+}
+
+func (params CredentialsParams) deepCopy() CredentialsParams {
+	paramsCopy := params
+	paramsCopy.Scopes = make([]string, len(params.Scopes))
+	copy(paramsCopy.Scopes, params.Scopes)
+	return paramsCopy
+}
 
 // DefaultClient returns an HTTP Client that uses the
 // DefaultTokenSource to obtain authentication credentials.
@@ -58,26 +89,33 @@ func DefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSourc
 	return creds.TokenSource, nil
 }
 
-// FindDefaultCredentials searches for "Application Default Credentials".
+// FindDefaultCredentialsWithParams searches for "Application Default Credentials".
 //
 // It looks for credentials in the following places,
 // preferring the first location found:
 //
-//   1. A JSON file whose path is specified by the
-//      GOOGLE_APPLICATION_CREDENTIALS environment variable.
-//   2. A JSON file in a location known to the gcloud command-line tool.
-//      On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
-//      On other systems, $HOME/.config/gcloud/application_default_credentials.json.
-//   3. On Google App Engine standard first generation runtimes (<= Go 1.9) it uses
-//      the appengine.AccessToken function.
-//   4. On Google Compute Engine, Google App Engine standard second generation runtimes
-//      (>= Go 1.11), and Google App Engine flexible environment, it fetches
-//      credentials from the metadata server.
-func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials, error) {
+//  1. A JSON file whose path is specified by the
+//     GOOGLE_APPLICATION_CREDENTIALS environment variable.
+//     For workload identity federation, refer to
+//     https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation on
+//     how to generate the JSON configuration file for on-prem/non-Google cloud
+//     platforms.
+//  2. A JSON file in a location known to the gcloud command-line tool.
+//     On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
+//     On other systems, $HOME/.config/gcloud/application_default_credentials.json.
+//  3. On Google App Engine standard first generation runtimes (<= Go 1.9) it uses
+//     the appengine.AccessToken function.
+//  4. On Google Compute Engine, Google App Engine standard second generation runtimes
+//     (>= Go 1.11), and Google App Engine flexible environment, it fetches
+//     credentials from the metadata server.
+func FindDefaultCredentialsWithParams(ctx context.Context, params CredentialsParams) (*Credentials, error) {
+	// Make defensive copy of the slices in params.
+	params = params.deepCopy()
+
 	// First, try the environment variable.
 	const envVar = "GOOGLE_APPLICATION_CREDENTIALS"
 	if filename := os.Getenv(envVar); filename != "" {
-		creds, err := readCredentialsFile(ctx, filename, scopes)
+		creds, err := readCredentialsFile(ctx, filename, params)
 		if err != nil {
 			return nil, fmt.Errorf("google: error getting credentials using %v environment variable: %v", envVar, err)
 		}
@@ -86,7 +124,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 
 	// Second, try a well-known file.
 	filename := wellKnownFile()
-	if creds, err := readCredentialsFile(ctx, filename, scopes); err == nil {
+	if creds, err := readCredentialsFile(ctx, filename, params); err == nil {
 		return creds, nil
 	} else if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("google: error getting credentials using well-known file (%v): %v", filename, err)
@@ -98,7 +136,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 	if appengineTokenFunc != nil {
 		return &DefaultCredentials{
 			ProjectID:   appengineAppIDFunc(ctx),
-			TokenSource: AppEngineTokenSource(ctx, scopes...),
+			TokenSource: AppEngineTokenSource(ctx, params.Scopes...),
 		}, nil
 	}
 
@@ -108,7 +146,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 		id, _ := metadata.ProjectID()
 		return &DefaultCredentials{
 			ProjectID:   id,
-			TokenSource: ComputeTokenSource("", scopes...),
+			TokenSource: ComputeTokenSource("", params.Scopes...),
 		}, nil
 	}
 
@@ -117,16 +155,38 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 	return nil, fmt.Errorf("google: could not find default credentials. See %v for more information.", url)
 }
 
-// CredentialsFromJSON obtains Google credentials from a JSON value. The JSON can
-// represent either a Google Developers Console client_credentials.json file (as in
-// ConfigFromJSON) or a Google Developers service account key file (as in
-// JWTConfigFromJSON).
-func CredentialsFromJSON(ctx context.Context, jsonData []byte, scopes ...string) (*Credentials, error) {
+// FindDefaultCredentials invokes FindDefaultCredentialsWithParams with the specified scopes.
+func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials, error) {
+	var params CredentialsParams
+	params.Scopes = scopes
+	return FindDefaultCredentialsWithParams(ctx, params)
+}
+
+// CredentialsFromJSONWithParams obtains Google credentials from a JSON value. The JSON can
+// represent either a Google Developers Console client_credentials.json file (as in ConfigFromJSON),
+// a Google Developers service account key file, a gcloud user credentials file (a.k.a. refresh
+// token JSON), or the JSON configuration file for workload identity federation in non-Google cloud
+// platforms (see https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation).
+func CredentialsFromJSONWithParams(ctx context.Context, jsonData []byte, params CredentialsParams) (*Credentials, error) {
+	// Make defensive copy of the slices in params.
+	params = params.deepCopy()
+
+	// First, attempt to parse jsonData as a Google Developers Console client_credentials.json.
+	config, _ := ConfigFromJSON(jsonData, params.Scopes...)
+	if config != nil {
+		return &Credentials{
+			ProjectID:   "",
+			TokenSource: authhandler.TokenSource(ctx, config, params.State, params.AuthHandler),
+			JSON:        jsonData,
+		}, nil
+	}
+
+	// Otherwise, parse jsonData as one of the other supported credentials files.
 	var f credentialsFile
 	if err := json.Unmarshal(jsonData, &f); err != nil {
 		return nil, err
 	}
-	ts, err := f.tokenSource(ctx, append([]string(nil), scopes...))
+	ts, err := f.tokenSource(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +197,13 @@ func CredentialsFromJSON(ctx context.Context, jsonData []byte, scopes ...string)
 	}, nil
 }
 
+// CredentialsFromJSON invokes CredentialsFromJSONWithParams with the specified scopes.
+func CredentialsFromJSON(ctx context.Context, jsonData []byte, scopes ...string) (*Credentials, error) {
+	var params CredentialsParams
+	params.Scopes = scopes
+	return CredentialsFromJSONWithParams(ctx, jsonData, params)
+}
+
 func wellKnownFile() string {
 	const f = "application_default_credentials.json"
 	if runtime.GOOS == "windows" {
@@ -145,10 +212,10 @@ func wellKnownFile() string {
 	return filepath.Join(guessUnixHomeDir(), ".config", "gcloud", f)
 }
 
-func readCredentialsFile(ctx context.Context, filename string, scopes []string) (*DefaultCredentials, error) {
+func readCredentialsFile(ctx context.Context, filename string, params CredentialsParams) (*DefaultCredentials, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return CredentialsFromJSON(ctx, b, scopes...)
+	return CredentialsFromJSONWithParams(ctx, b, params)
 }

--- a/vendor/golang.org/x/oauth2/google/doc.go
+++ b/vendor/golang.org/x/oauth2/google/doc.go
@@ -4,23 +4,54 @@
 
 // Package google provides support for making OAuth2 authorized and authenticated
 // HTTP requests to Google APIs. It supports the Web server flow, client-side
-// credentials, service accounts, Google Compute Engine service accounts, and Google
-// App Engine service accounts.
+// credentials, service accounts, Google Compute Engine service accounts,
+// Google App Engine service accounts and workload identity federation
+// from non-Google cloud platforms.
 //
 // A brief overview of the package follows. For more information, please read
 // https://developers.google.com/accounts/docs/OAuth2
 // and
 // https://developers.google.com/accounts/docs/application-default-credentials.
+// For more information on using workload identity federation, refer to
+// https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation.
 //
-// OAuth2 Configs
+// # OAuth2 Configs
 //
 // Two functions in this package return golang.org/x/oauth2.Config values from Google credential
 // data. Google supports two JSON formats for OAuth2 credentials: one is handled by ConfigFromJSON,
 // the other by JWTConfigFromJSON. The returned Config can be used to obtain a TokenSource or
 // create an http.Client.
 //
+// # Workload Identity Federation
 //
-// Credentials
+// Using workload identity federation, your application can access Google Cloud
+// resources from Amazon Web Services (AWS), Microsoft Azure or any identity
+// provider that supports OpenID Connect (OIDC).
+// Traditionally, applications running outside Google Cloud have used service
+// account keys to access Google Cloud resources. Using identity federation,
+// you can allow your workload to impersonate a service account.
+// This lets you access Google Cloud resources directly, eliminating the
+// maintenance and security burden associated with service account keys.
+//
+// Follow the detailed instructions on how to configure Workload Identity Federation
+// in various platforms:
+//
+//	Amazon Web Services (AWS): https://cloud.google.com/iam/docs/access-resources-aws
+//	Microsoft Azure: https://cloud.google.com/iam/docs/access-resources-azure
+//	OIDC identity provider: https://cloud.google.com/iam/docs/access-resources-oidc
+//
+// For OIDC providers, the library can retrieve OIDC tokens either from a
+// local file location (file-sourced credentials) or from a local server
+// (URL-sourced credentials).
+// For file-sourced credentials, a background process needs to be continuously
+// refreshing the file location with a new OIDC token prior to expiration.
+// For tokens with one hour lifetimes, the token needs to be updated in the file
+// every hour. The token can be stored directly as plain text or in JSON format.
+// For URL-sourced credentials, a local server needs to host a GET endpoint to
+// return the OIDC token. The response can be in plain text or JSON.
+// Additional required request headers can also be specified.
+//
+// # Credentials
 //
 // The Credentials type represents Google credentials, including Application Default
 // Credentials.
@@ -28,6 +59,13 @@
 // Use FindDefaultCredentials to obtain Application Default Credentials.
 // FindDefaultCredentials looks in some well-known places for a credentials file, and
 // will call AppEngineTokenSource or ComputeTokenSource as needed.
+//
+// Application Default Credentials also support workload identity federation to
+// access Google Cloud resources from non-Google Cloud platforms including Amazon
+// Web Services (AWS), Microsoft Azure or any identity provider that supports
+// OpenID Connect (OIDC). Workload identity federation is recommended for
+// non-Google Cloud environments as it avoids the need to download, manage and
+// store service account private keys locally.
 //
 // DefaultClient and DefaultTokenSource are convenience methods. They first call FindDefaultCredentials,
 // then use the credentials to construct an http.Client or an oauth2.TokenSource.

--- a/vendor/golang.org/x/oauth2/google/google.go
+++ b/vendor/golang.org/x/oauth2/google/google.go
@@ -15,10 +15,11 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google/internal/externalaccount"
 	"golang.org/x/oauth2/jwt"
 )
 
-// Endpoint is Google's OAuth 2.0 endpoint.
+// Endpoint is Google's OAuth 2.0 default endpoint.
 var Endpoint = oauth2.Endpoint{
 	AuthURL:   "https://accounts.google.com/o/oauth2/auth",
 	TokenURL:  "https://oauth2.googleapis.com/token",
@@ -86,23 +87,26 @@ func JWTConfigFromJSON(jsonKey []byte, scope ...string) (*jwt.Config, error) {
 		return nil, fmt.Errorf("google: read JWT from JSON credentials: 'type' field is %q (expected %q)", f.Type, serviceAccountKey)
 	}
 	scope = append([]string(nil), scope...) // copy
-	return f.jwtConfig(scope), nil
+	return f.jwtConfig(scope, ""), nil
 }
 
 // JSON key file types.
 const (
-	serviceAccountKey  = "service_account"
-	userCredentialsKey = "authorized_user"
+	serviceAccountKey          = "service_account"
+	userCredentialsKey         = "authorized_user"
+	externalAccountKey         = "external_account"
+	impersonatedServiceAccount = "impersonated_service_account"
 )
 
 // credentialsFile is the unmarshalled representation of a credentials file.
 type credentialsFile struct {
-	Type string `json:"type"` // serviceAccountKey or userCredentialsKey
+	Type string `json:"type"`
 
 	// Service Account fields
 	ClientEmail  string `json:"client_email"`
 	PrivateKeyID string `json:"private_key_id"`
 	PrivateKey   string `json:"private_key"`
+	AuthURL      string `json:"auth_uri"`
 	TokenURL     string `json:"token_uri"`
 	ProjectID    string `json:"project_id"`
 
@@ -111,15 +115,30 @@ type credentialsFile struct {
 	ClientSecret string `json:"client_secret"`
 	ClientID     string `json:"client_id"`
 	RefreshToken string `json:"refresh_token"`
+
+	// External Account fields
+	Audience                       string                           `json:"audience"`
+	SubjectTokenType               string                           `json:"subject_token_type"`
+	TokenURLExternal               string                           `json:"token_url"`
+	TokenInfoURL                   string                           `json:"token_info_url"`
+	ServiceAccountImpersonationURL string                           `json:"service_account_impersonation_url"`
+	Delegates                      []string                         `json:"delegates"`
+	CredentialSource               externalaccount.CredentialSource `json:"credential_source"`
+	QuotaProjectID                 string                           `json:"quota_project_id"`
+	WorkforcePoolUserProject       string                           `json:"workforce_pool_user_project"`
+
+	// Service account impersonation
+	SourceCredentials *credentialsFile `json:"source_credentials"`
 }
 
-func (f *credentialsFile) jwtConfig(scopes []string) *jwt.Config {
+func (f *credentialsFile) jwtConfig(scopes []string, subject string) *jwt.Config {
 	cfg := &jwt.Config{
 		Email:        f.ClientEmail,
 		PrivateKey:   []byte(f.PrivateKey),
 		PrivateKeyID: f.PrivateKeyID,
 		Scopes:       scopes,
 		TokenURL:     f.TokenURL,
+		Subject:      subject, // This is the user email to impersonate
 	}
 	if cfg.TokenURL == "" {
 		cfg.TokenURL = JWTTokenURL
@@ -127,20 +146,62 @@ func (f *credentialsFile) jwtConfig(scopes []string) *jwt.Config {
 	return cfg
 }
 
-func (f *credentialsFile) tokenSource(ctx context.Context, scopes []string) (oauth2.TokenSource, error) {
+func (f *credentialsFile) tokenSource(ctx context.Context, params CredentialsParams) (oauth2.TokenSource, error) {
 	switch f.Type {
 	case serviceAccountKey:
-		cfg := f.jwtConfig(scopes)
+		cfg := f.jwtConfig(params.Scopes, params.Subject)
 		return cfg.TokenSource(ctx), nil
 	case userCredentialsKey:
 		cfg := &oauth2.Config{
 			ClientID:     f.ClientID,
 			ClientSecret: f.ClientSecret,
-			Scopes:       scopes,
-			Endpoint:     Endpoint,
+			Scopes:       params.Scopes,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:   f.AuthURL,
+				TokenURL:  f.TokenURL,
+				AuthStyle: oauth2.AuthStyleInParams,
+			},
+		}
+		if cfg.Endpoint.AuthURL == "" {
+			cfg.Endpoint.AuthURL = Endpoint.AuthURL
+		}
+		if cfg.Endpoint.TokenURL == "" {
+			cfg.Endpoint.TokenURL = Endpoint.TokenURL
 		}
 		tok := &oauth2.Token{RefreshToken: f.RefreshToken}
 		return cfg.TokenSource(ctx, tok), nil
+	case externalAccountKey:
+		cfg := &externalaccount.Config{
+			Audience:                       f.Audience,
+			SubjectTokenType:               f.SubjectTokenType,
+			TokenURL:                       f.TokenURLExternal,
+			TokenInfoURL:                   f.TokenInfoURL,
+			ServiceAccountImpersonationURL: f.ServiceAccountImpersonationURL,
+			ClientSecret:                   f.ClientSecret,
+			ClientID:                       f.ClientID,
+			CredentialSource:               f.CredentialSource,
+			QuotaProjectID:                 f.QuotaProjectID,
+			Scopes:                         params.Scopes,
+			WorkforcePoolUserProject:       f.WorkforcePoolUserProject,
+		}
+		return cfg.TokenSource(ctx)
+	case impersonatedServiceAccount:
+		if f.ServiceAccountImpersonationURL == "" || f.SourceCredentials == nil {
+			return nil, errors.New("missing 'source_credentials' field or 'service_account_impersonation_url' in credentials")
+		}
+
+		ts, err := f.SourceCredentials.tokenSource(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		imp := externalaccount.ImpersonateTokenSource{
+			Ctx:       ctx,
+			URL:       f.ServiceAccountImpersonationURL,
+			Scopes:    params.Scopes,
+			Ts:        ts,
+			Delegates: f.Delegates,
+		}
+		return oauth2.ReuseTokenSource(nil, imp), nil
 	case "":
 		return nil, errors.New("missing 'type' field in credentials")
 	default:

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/aws.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/aws.go
@@ -1,0 +1,530 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+type awsSecurityCredentials struct {
+	AccessKeyID     string `json:"AccessKeyID"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	SecurityToken   string `json:"Token"`
+}
+
+// awsRequestSigner is a utility class to sign http requests using a AWS V4 signature.
+type awsRequestSigner struct {
+	RegionName             string
+	AwsSecurityCredentials awsSecurityCredentials
+}
+
+// getenv aliases os.Getenv for testing
+var getenv = os.Getenv
+
+const (
+	// AWS Signature Version 4 signing algorithm identifier.
+	awsAlgorithm = "AWS4-HMAC-SHA256"
+
+	// The termination string for the AWS credential scope value as defined in
+	// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+	awsRequestType = "aws4_request"
+
+	// The AWS authorization header name for the security session token if available.
+	awsSecurityTokenHeader = "x-amz-security-token"
+
+	// The name of the header containing the session token for metadata endpoint calls
+	awsIMDSv2SessionTokenHeader = "X-aws-ec2-metadata-token"
+
+	awsIMDSv2SessionTtlHeader = "X-aws-ec2-metadata-token-ttl-seconds"
+
+	awsIMDSv2SessionTtl = "300"
+
+	// The AWS authorization header name for the auto-generated date.
+	awsDateHeader = "x-amz-date"
+
+	awsTimeFormatLong  = "20060102T150405Z"
+	awsTimeFormatShort = "20060102"
+)
+
+func getSha256(input []byte) (string, error) {
+	hash := sha256.New()
+	if _, err := hash.Write(input); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func getHmacSha256(key, input []byte) ([]byte, error) {
+	hash := hmac.New(sha256.New, key)
+	if _, err := hash.Write(input); err != nil {
+		return nil, err
+	}
+	return hash.Sum(nil), nil
+}
+
+func cloneRequest(r *http.Request) *http.Request {
+	r2 := new(http.Request)
+	*r2 = *r
+	if r.Header != nil {
+		r2.Header = make(http.Header, len(r.Header))
+
+		// Find total number of values.
+		headerCount := 0
+		for _, headerValues := range r.Header {
+			headerCount += len(headerValues)
+		}
+		copiedHeaders := make([]string, headerCount) // shared backing array for headers' values
+
+		for headerKey, headerValues := range r.Header {
+			headerCount = copy(copiedHeaders, headerValues)
+			r2.Header[headerKey] = copiedHeaders[:headerCount:headerCount]
+			copiedHeaders = copiedHeaders[headerCount:]
+		}
+	}
+	return r2
+}
+
+func canonicalPath(req *http.Request) string {
+	result := req.URL.EscapedPath()
+	if result == "" {
+		return "/"
+	}
+	return path.Clean(result)
+}
+
+func canonicalQuery(req *http.Request) string {
+	queryValues := req.URL.Query()
+	for queryKey := range queryValues {
+		sort.Strings(queryValues[queryKey])
+	}
+	return queryValues.Encode()
+}
+
+func canonicalHeaders(req *http.Request) (string, string) {
+	// Header keys need to be sorted alphabetically.
+	var headers []string
+	lowerCaseHeaders := make(http.Header)
+	for k, v := range req.Header {
+		k := strings.ToLower(k)
+		if _, ok := lowerCaseHeaders[k]; ok {
+			// include additional values
+			lowerCaseHeaders[k] = append(lowerCaseHeaders[k], v...)
+		} else {
+			headers = append(headers, k)
+			lowerCaseHeaders[k] = v
+		}
+	}
+	sort.Strings(headers)
+
+	var fullHeaders bytes.Buffer
+	for _, header := range headers {
+		headerValue := strings.Join(lowerCaseHeaders[header], ",")
+		fullHeaders.WriteString(header)
+		fullHeaders.WriteRune(':')
+		fullHeaders.WriteString(headerValue)
+		fullHeaders.WriteRune('\n')
+	}
+
+	return strings.Join(headers, ";"), fullHeaders.String()
+}
+
+func requestDataHash(req *http.Request) (string, error) {
+	var requestData []byte
+	if req.Body != nil {
+		requestBody, err := req.GetBody()
+		if err != nil {
+			return "", err
+		}
+		defer requestBody.Close()
+
+		requestData, err = ioutil.ReadAll(io.LimitReader(requestBody, 1<<20))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return getSha256(requestData)
+}
+
+func requestHost(req *http.Request) string {
+	if req.Host != "" {
+		return req.Host
+	}
+	return req.URL.Host
+}
+
+func canonicalRequest(req *http.Request, canonicalHeaderColumns, canonicalHeaderData string) (string, error) {
+	dataHash, err := requestDataHash(req)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", req.Method, canonicalPath(req), canonicalQuery(req), canonicalHeaderData, canonicalHeaderColumns, dataHash), nil
+}
+
+// SignRequest adds the appropriate headers to an http.Request
+// or returns an error if something prevented this.
+func (rs *awsRequestSigner) SignRequest(req *http.Request) error {
+	signedRequest := cloneRequest(req)
+	timestamp := now()
+
+	signedRequest.Header.Add("host", requestHost(req))
+
+	if rs.AwsSecurityCredentials.SecurityToken != "" {
+		signedRequest.Header.Add(awsSecurityTokenHeader, rs.AwsSecurityCredentials.SecurityToken)
+	}
+
+	if signedRequest.Header.Get("date") == "" {
+		signedRequest.Header.Add(awsDateHeader, timestamp.Format(awsTimeFormatLong))
+	}
+
+	authorizationCode, err := rs.generateAuthentication(signedRequest, timestamp)
+	if err != nil {
+		return err
+	}
+	signedRequest.Header.Set("Authorization", authorizationCode)
+
+	req.Header = signedRequest.Header
+	return nil
+}
+
+func (rs *awsRequestSigner) generateAuthentication(req *http.Request, timestamp time.Time) (string, error) {
+	canonicalHeaderColumns, canonicalHeaderData := canonicalHeaders(req)
+
+	dateStamp := timestamp.Format(awsTimeFormatShort)
+	serviceName := ""
+	if splitHost := strings.Split(requestHost(req), "."); len(splitHost) > 0 {
+		serviceName = splitHost[0]
+	}
+
+	credentialScope := fmt.Sprintf("%s/%s/%s/%s", dateStamp, rs.RegionName, serviceName, awsRequestType)
+
+	requestString, err := canonicalRequest(req, canonicalHeaderColumns, canonicalHeaderData)
+	if err != nil {
+		return "", err
+	}
+	requestHash, err := getSha256([]byte(requestString))
+	if err != nil {
+		return "", err
+	}
+
+	stringToSign := fmt.Sprintf("%s\n%s\n%s\n%s", awsAlgorithm, timestamp.Format(awsTimeFormatLong), credentialScope, requestHash)
+
+	signingKey := []byte("AWS4" + rs.AwsSecurityCredentials.SecretAccessKey)
+	for _, signingInput := range []string{
+		dateStamp, rs.RegionName, serviceName, awsRequestType, stringToSign,
+	} {
+		signingKey, err = getHmacSha256(signingKey, []byte(signingInput))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s", awsAlgorithm, rs.AwsSecurityCredentials.AccessKeyID, credentialScope, canonicalHeaderColumns, hex.EncodeToString(signingKey)), nil
+}
+
+type awsCredentialSource struct {
+	EnvironmentID               string
+	RegionURL                   string
+	RegionalCredVerificationURL string
+	CredVerificationURL         string
+	IMDSv2SessionTokenURL       string
+	TargetResource              string
+	requestSigner               *awsRequestSigner
+	region                      string
+	ctx                         context.Context
+	client                      *http.Client
+}
+
+type awsRequestHeader struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type awsRequest struct {
+	URL     string             `json:"url"`
+	Method  string             `json:"method"`
+	Headers []awsRequestHeader `json:"headers"`
+}
+
+func (cs awsCredentialSource) doRequest(req *http.Request) (*http.Response, error) {
+	if cs.client == nil {
+		cs.client = oauth2.NewClient(cs.ctx, nil)
+	}
+	return cs.client.Do(req.WithContext(cs.ctx))
+}
+
+func (cs awsCredentialSource) subjectToken() (string, error) {
+	if cs.requestSigner == nil {
+		awsSessionToken, err := cs.getAWSSessionToken()
+		if err != nil {
+			return "", err
+		}
+
+		headers := make(map[string]string)
+		if awsSessionToken != "" {
+			headers[awsIMDSv2SessionTokenHeader] = awsSessionToken
+		}
+
+		awsSecurityCredentials, err := cs.getSecurityCredentials(headers)
+		if err != nil {
+			return "", err
+		}
+
+		if cs.region, err = cs.getRegion(headers); err != nil {
+			return "", err
+		}
+
+		cs.requestSigner = &awsRequestSigner{
+			RegionName:             cs.region,
+			AwsSecurityCredentials: awsSecurityCredentials,
+		}
+	}
+
+	// Generate the signed request to AWS STS GetCallerIdentity API.
+	// Use the required regional endpoint. Otherwise, the request will fail.
+	req, err := http.NewRequest("POST", strings.Replace(cs.RegionalCredVerificationURL, "{region}", cs.region, 1), nil)
+	if err != nil {
+		return "", err
+	}
+	// The full, canonical resource name of the workload identity pool
+	// provider, with or without the HTTPS prefix.
+	// Including this header as part of the signature is recommended to
+	// ensure data integrity.
+	if cs.TargetResource != "" {
+		req.Header.Add("x-goog-cloud-target-resource", cs.TargetResource)
+	}
+	cs.requestSigner.SignRequest(req)
+
+	/*
+	   The GCP STS endpoint expects the headers to be formatted as:
+	   # [
+	   #   {key: 'x-amz-date', value: '...'},
+	   #   {key: 'Authorization', value: '...'},
+	   #   ...
+	   # ]
+	   # And then serialized as:
+	   # quote(json.dumps({
+	   #   url: '...',
+	   #   method: 'POST',
+	   #   headers: [{key: 'x-amz-date', value: '...'}, ...]
+	   # }))
+	*/
+
+	awsSignedReq := awsRequest{
+		URL:    req.URL.String(),
+		Method: "POST",
+	}
+	for headerKey, headerList := range req.Header {
+		for _, headerValue := range headerList {
+			awsSignedReq.Headers = append(awsSignedReq.Headers, awsRequestHeader{
+				Key:   headerKey,
+				Value: headerValue,
+			})
+		}
+	}
+	sort.Slice(awsSignedReq.Headers, func(i, j int) bool {
+		headerCompare := strings.Compare(awsSignedReq.Headers[i].Key, awsSignedReq.Headers[j].Key)
+		if headerCompare == 0 {
+			return strings.Compare(awsSignedReq.Headers[i].Value, awsSignedReq.Headers[j].Value) < 0
+		}
+		return headerCompare < 0
+	})
+
+	result, err := json.Marshal(awsSignedReq)
+	if err != nil {
+		return "", err
+	}
+	return url.QueryEscape(string(result)), nil
+}
+
+func (cs *awsCredentialSource) getAWSSessionToken() (string, error) {
+	if cs.IMDSv2SessionTokenURL == "" {
+		return "", nil
+	}
+
+	req, err := http.NewRequest("PUT", cs.IMDSv2SessionTokenURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add(awsIMDSv2SessionTtlHeader, awsIMDSv2SessionTtl)
+
+	resp, err := cs.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("oauth2/google: unable to retrieve AWS session token - %s", string(respBody))
+	}
+
+	return string(respBody), nil
+}
+
+func (cs *awsCredentialSource) getRegion(headers map[string]string) (string, error) {
+	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
+		return envAwsRegion, nil
+	}
+	if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
+		return envAwsRegion, nil
+	}
+
+	if cs.RegionURL == "" {
+		return "", errors.New("oauth2/google: unable to determine AWS region")
+	}
+
+	req, err := http.NewRequest("GET", cs.RegionURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for name, value := range headers {
+		req.Header.Add(name, value)
+	}
+
+	resp, err := cs.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("oauth2/google: unable to retrieve AWS region - %s", string(respBody))
+	}
+
+	// This endpoint will return the region in format: us-east-2b.
+	// Only the us-east-2 part should be used.
+	respBodyEnd := 0
+	if len(respBody) > 1 {
+		respBodyEnd = len(respBody) - 1
+	}
+	return string(respBody[:respBodyEnd]), nil
+}
+
+func (cs *awsCredentialSource) getSecurityCredentials(headers map[string]string) (result awsSecurityCredentials, err error) {
+	if accessKeyID := getenv("AWS_ACCESS_KEY_ID"); accessKeyID != "" {
+		if secretAccessKey := getenv("AWS_SECRET_ACCESS_KEY"); secretAccessKey != "" {
+			return awsSecurityCredentials{
+				AccessKeyID:     accessKeyID,
+				SecretAccessKey: secretAccessKey,
+				SecurityToken:   getenv("AWS_SESSION_TOKEN"),
+			}, nil
+		}
+	}
+
+	roleName, err := cs.getMetadataRoleName(headers)
+	if err != nil {
+		return
+	}
+
+	credentials, err := cs.getMetadataSecurityCredentials(roleName, headers)
+	if err != nil {
+		return
+	}
+
+	if credentials.AccessKeyID == "" {
+		return result, errors.New("oauth2/google: missing AccessKeyId credential")
+	}
+
+	if credentials.SecretAccessKey == "" {
+		return result, errors.New("oauth2/google: missing SecretAccessKey credential")
+	}
+
+	return credentials, nil
+}
+
+func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string, headers map[string]string) (awsSecurityCredentials, error) {
+	var result awsSecurityCredentials
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", cs.CredVerificationURL, roleName), nil)
+	if err != nil {
+		return result, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	for name, value := range headers {
+		req.Header.Add(name, value)
+	}
+
+	resp, err := cs.doRequest(req)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return result, err
+	}
+
+	if resp.StatusCode != 200 {
+		return result, fmt.Errorf("oauth2/google: unable to retrieve AWS security credentials - %s", string(respBody))
+	}
+
+	err = json.Unmarshal(respBody, &result)
+	return result, err
+}
+
+func (cs *awsCredentialSource) getMetadataRoleName(headers map[string]string) (string, error) {
+	if cs.CredVerificationURL == "" {
+		return "", errors.New("oauth2/google: unable to determine the AWS metadata server security credentials endpoint")
+	}
+
+	req, err := http.NewRequest("GET", cs.CredVerificationURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for name, value := range headers {
+		req.Header.Add(name, value)
+	}
+
+	resp, err := cs.doRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("oauth2/google: unable to retrieve AWS role name - %s", string(respBody))
+	}
+
+	return string(respBody), nil
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/basecredentials.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/basecredentials.go
@@ -1,0 +1,277 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// now aliases time.Now for testing
+var now = func() time.Time {
+	return time.Now().UTC()
+}
+
+// Config stores the configuration for fetching tokens with external credentials.
+type Config struct {
+	// Audience is the Secure Token Service (STS) audience which contains the resource name for the workload
+	// identity pool or the workforce pool and the provider identifier in that pool.
+	Audience string
+	// SubjectTokenType is the STS token type based on the Oauth2.0 token exchange spec
+	// e.g. `urn:ietf:params:oauth:token-type:jwt`.
+	SubjectTokenType string
+	// TokenURL is the STS token exchange endpoint.
+	TokenURL string
+	// TokenInfoURL is the token_info endpoint used to retrieve the account related information (
+	// user attributes like account identifier, eg. email, username, uid, etc). This is
+	// needed for gCloud session account identification.
+	TokenInfoURL string
+	// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
+	// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
+	ServiceAccountImpersonationURL string
+	// ClientSecret is currently only required if token_info endpoint also
+	// needs to be called with the generated GCP access token. When provided, STS will be
+	// called with additional basic authentication using client_id as username and client_secret as password.
+	ClientSecret string
+	// ClientID is only required in conjunction with ClientSecret, as described above.
+	ClientID string
+	// CredentialSource contains the necessary information to retrieve the token itself, as well
+	// as some environmental information.
+	CredentialSource CredentialSource
+	// QuotaProjectID is injected by gCloud. If the value is non-empty, the Auth libraries
+	// will set the x-goog-user-project which overrides the project associated with the credentials.
+	QuotaProjectID string
+	// Scopes contains the desired scopes for the returned access token.
+	Scopes []string
+	// The optional workforce pool user project number when the credential
+	// corresponds to a workforce pool and not a workload identity pool.
+	// The underlying principal must still have serviceusage.services.use IAM
+	// permission to use the project for billing/quota.
+	WorkforcePoolUserProject string
+}
+
+// Each element consists of a list of patterns.  validateURLs checks for matches
+// that include all elements in a given list, in that order.
+
+var (
+	validTokenURLPatterns = []*regexp.Regexp{
+		// The complicated part in the middle matches any number of characters that
+		// aren't period, spaces, or slashes.
+		regexp.MustCompile(`(?i)^[^\.\s\/\\]+\.sts\.googleapis\.com$`),
+		regexp.MustCompile(`(?i)^sts\.googleapis\.com$`),
+		regexp.MustCompile(`(?i)^sts\.[^\.\s\/\\]+\.googleapis\.com$`),
+		regexp.MustCompile(`(?i)^[^\.\s\/\\]+-sts\.googleapis\.com$`),
+	}
+	validImpersonateURLPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`^[^\.\s\/\\]+\.iamcredentials\.googleapis\.com$`),
+		regexp.MustCompile(`^iamcredentials\.googleapis\.com$`),
+		regexp.MustCompile(`^iamcredentials\.[^\.\s\/\\]+\.googleapis\.com$`),
+		regexp.MustCompile(`^[^\.\s\/\\]+-iamcredentials\.googleapis\.com$`),
+	}
+	validWorkforceAudiencePattern *regexp.Regexp = regexp.MustCompile(`//iam\.googleapis\.com/locations/[^/]+/workforcePools/`)
+)
+
+func validateURL(input string, patterns []*regexp.Regexp, scheme string) bool {
+	parsed, err := url.Parse(input)
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(parsed.Scheme, scheme) {
+		return false
+	}
+	toTest := parsed.Host
+
+	for _, pattern := range patterns {
+		if pattern.MatchString(toTest) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateWorkforceAudience(input string) bool {
+	return validWorkforceAudiencePattern.MatchString(input)
+}
+
+// TokenSource Returns an external account TokenSource struct. This is to be called by package google to construct a google.Credentials.
+func (c *Config) TokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	return c.tokenSource(ctx, validTokenURLPatterns, validImpersonateURLPatterns, "https")
+}
+
+// tokenSource is a private function that's directly called by some of the tests,
+// because the unit test URLs are mocked, and would otherwise fail the
+// validity check.
+func (c *Config) tokenSource(ctx context.Context, tokenURLValidPats []*regexp.Regexp, impersonateURLValidPats []*regexp.Regexp, scheme string) (oauth2.TokenSource, error) {
+	valid := validateURL(c.TokenURL, tokenURLValidPats, scheme)
+	if !valid {
+		return nil, fmt.Errorf("oauth2/google: invalid TokenURL provided while constructing tokenSource")
+	}
+
+	if c.ServiceAccountImpersonationURL != "" {
+		valid := validateURL(c.ServiceAccountImpersonationURL, impersonateURLValidPats, scheme)
+		if !valid {
+			return nil, fmt.Errorf("oauth2/google: invalid ServiceAccountImpersonationURL provided while constructing tokenSource")
+		}
+	}
+
+	if c.WorkforcePoolUserProject != "" {
+		valid := validateWorkforceAudience(c.Audience)
+		if !valid {
+			return nil, fmt.Errorf("oauth2/google: workforce_pool_user_project should not be set for non-workforce pool credentials")
+		}
+	}
+
+	ts := tokenSource{
+		ctx:  ctx,
+		conf: c,
+	}
+	if c.ServiceAccountImpersonationURL == "" {
+		return oauth2.ReuseTokenSource(nil, ts), nil
+	}
+	scopes := c.Scopes
+	ts.conf.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
+	imp := ImpersonateTokenSource{
+		Ctx:    ctx,
+		URL:    c.ServiceAccountImpersonationURL,
+		Scopes: scopes,
+		Ts:     oauth2.ReuseTokenSource(nil, ts),
+	}
+	return oauth2.ReuseTokenSource(nil, imp), nil
+}
+
+// Subject token file types.
+const (
+	fileTypeText = "text"
+	fileTypeJSON = "json"
+)
+
+type format struct {
+	// Type is either "text" or "json". When not provided "text" type is assumed.
+	Type string `json:"type"`
+	// SubjectTokenFieldName is only required for JSON format. This would be "access_token" for azure.
+	SubjectTokenFieldName string `json:"subject_token_field_name"`
+}
+
+// CredentialSource stores the information necessary to retrieve the credentials for the STS exchange.
+// Either the File or the URL field should be filled, depending on the kind of credential in question.
+// The EnvironmentID should start with AWS if being used for an AWS credential.
+type CredentialSource struct {
+	File string `json:"file"`
+
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers"`
+
+	EnvironmentID               string `json:"environment_id"`
+	RegionURL                   string `json:"region_url"`
+	RegionalCredVerificationURL string `json:"regional_cred_verification_url"`
+	CredVerificationURL         string `json:"cred_verification_url"`
+	IMDSv2SessionTokenURL       string `json:"imdsv2_session_token_url"`
+	Format                      format `json:"format"`
+}
+
+// parse determines the type of CredentialSource needed
+func (c *Config) parse(ctx context.Context) (baseCredentialSource, error) {
+	if len(c.CredentialSource.EnvironmentID) > 3 && c.CredentialSource.EnvironmentID[:3] == "aws" {
+		if awsVersion, err := strconv.Atoi(c.CredentialSource.EnvironmentID[3:]); err == nil {
+			if awsVersion != 1 {
+				return nil, fmt.Errorf("oauth2/google: aws version '%d' is not supported in the current build", awsVersion)
+			}
+
+			awsCredSource := awsCredentialSource{
+				EnvironmentID:               c.CredentialSource.EnvironmentID,
+				RegionURL:                   c.CredentialSource.RegionURL,
+				RegionalCredVerificationURL: c.CredentialSource.RegionalCredVerificationURL,
+				CredVerificationURL:         c.CredentialSource.URL,
+				TargetResource:              c.Audience,
+				ctx:                         ctx,
+			}
+			if c.CredentialSource.IMDSv2SessionTokenURL != "" {
+				awsCredSource.IMDSv2SessionTokenURL = c.CredentialSource.IMDSv2SessionTokenURL
+			}
+
+			return awsCredSource, nil
+		}
+	} else if c.CredentialSource.File != "" {
+		return fileCredentialSource{File: c.CredentialSource.File, Format: c.CredentialSource.Format}, nil
+	} else if c.CredentialSource.URL != "" {
+		return urlCredentialSource{URL: c.CredentialSource.URL, Headers: c.CredentialSource.Headers, Format: c.CredentialSource.Format, ctx: ctx}, nil
+	}
+	return nil, fmt.Errorf("oauth2/google: unable to parse credential source")
+}
+
+type baseCredentialSource interface {
+	subjectToken() (string, error)
+}
+
+// tokenSource is the source that handles external credentials. It is used to retrieve Tokens.
+type tokenSource struct {
+	ctx  context.Context
+	conf *Config
+}
+
+// Token allows tokenSource to conform to the oauth2.TokenSource interface.
+func (ts tokenSource) Token() (*oauth2.Token, error) {
+	conf := ts.conf
+
+	credSource, err := conf.parse(ts.ctx)
+	if err != nil {
+		return nil, err
+	}
+	subjectToken, err := credSource.subjectToken()
+
+	if err != nil {
+		return nil, err
+	}
+	stsRequest := stsTokenExchangeRequest{
+		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
+		Audience:           conf.Audience,
+		Scope:              conf.Scopes,
+		RequestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		SubjectToken:       subjectToken,
+		SubjectTokenType:   conf.SubjectTokenType,
+	}
+	header := make(http.Header)
+	header.Add("Content-Type", "application/x-www-form-urlencoded")
+	clientAuth := clientAuthentication{
+		AuthStyle:    oauth2.AuthStyleInHeader,
+		ClientID:     conf.ClientID,
+		ClientSecret: conf.ClientSecret,
+	}
+	var options map[string]interface{}
+	// Do not pass workforce_pool_user_project when client authentication is used.
+	// The client ID is sufficient for determining the user project.
+	if conf.WorkforcePoolUserProject != "" && conf.ClientID == "" {
+		options = map[string]interface{}{
+			"userProject": conf.WorkforcePoolUserProject,
+		}
+	}
+	stsResp, err := exchangeToken(ts.ctx, conf.TokenURL, &stsRequest, clientAuth, header, options)
+	if err != nil {
+		return nil, err
+	}
+
+	accessToken := &oauth2.Token{
+		AccessToken: stsResp.AccessToken,
+		TokenType:   stsResp.TokenType,
+	}
+	if stsResp.ExpiresIn < 0 {
+		return nil, fmt.Errorf("oauth2/google: got invalid expiry from security token service")
+	} else if stsResp.ExpiresIn >= 0 {
+		accessToken.Expiry = now().Add(time.Duration(stsResp.ExpiresIn) * time.Second)
+	}
+
+	if stsResp.RefreshToken != "" {
+		accessToken.RefreshToken = stsResp.RefreshToken
+	}
+	return accessToken, nil
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/clientauth.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/clientauth.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/oauth2"
+)
+
+// clientAuthentication represents an OAuth client ID and secret and the mechanism for passing these credentials as stated in rfc6749#2.3.1.
+type clientAuthentication struct {
+	// AuthStyle can be either basic or request-body
+	AuthStyle    oauth2.AuthStyle
+	ClientID     string
+	ClientSecret string
+}
+
+// InjectAuthentication is used to add authentication to a Secure Token Service exchange
+// request.  It modifies either the passed url.Values or http.Header depending on the desired
+// authentication format.
+func (c *clientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {
+	if c.ClientID == "" || c.ClientSecret == "" || values == nil || headers == nil {
+		return
+	}
+
+	switch c.AuthStyle {
+	case oauth2.AuthStyleInHeader: // AuthStyleInHeader corresponds to basic authentication as defined in rfc7617#2
+		plainHeader := c.ClientID + ":" + c.ClientSecret
+		headers.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(plainHeader)))
+	case oauth2.AuthStyleInParams: // AuthStyleInParams corresponds to request-body authentication with ClientID and ClientSecret in the message body.
+		values.Set("client_id", c.ClientID)
+		values.Set("client_secret", c.ClientSecret)
+	case oauth2.AuthStyleAutoDetect:
+		values.Set("client_id", c.ClientID)
+		values.Set("client_secret", c.ClientSecret)
+	default:
+		values.Set("client_id", c.ClientID)
+		values.Set("client_secret", c.ClientSecret)
+	}
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/err.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/err.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import "fmt"
+
+// Error for handling OAuth related error responses as stated in rfc6749#5.2.
+type Error struct {
+	Code        string
+	URI         string
+	Description string
+}
+
+func (err *Error) Error() string {
+	return fmt.Sprintf("got error code %s from %s: %s", err.Code, err.URI, err.Description)
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/filecredsource.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/filecredsource.go
@@ -1,0 +1,57 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+type fileCredentialSource struct {
+	File   string
+	Format format
+}
+
+func (cs fileCredentialSource) subjectToken() (string, error) {
+	tokenFile, err := os.Open(cs.File)
+	if err != nil {
+		return "", fmt.Errorf("oauth2/google: failed to open credential file %q", cs.File)
+	}
+	defer tokenFile.Close()
+	tokenBytes, err := ioutil.ReadAll(io.LimitReader(tokenFile, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("oauth2/google: failed to read credential file: %v", err)
+	}
+	tokenBytes = bytes.TrimSpace(tokenBytes)
+	switch cs.Format.Type {
+	case "json":
+		jsonData := make(map[string]interface{})
+		err = json.Unmarshal(tokenBytes, &jsonData)
+		if err != nil {
+			return "", fmt.Errorf("oauth2/google: failed to unmarshal subject token file: %v", err)
+		}
+		val, ok := jsonData[cs.Format.SubjectTokenFieldName]
+		if !ok {
+			return "", errors.New("oauth2/google: provided subject_token_field_name not found in credentials")
+		}
+		token, ok := val.(string)
+		if !ok {
+			return "", errors.New("oauth2/google: improperly formatted subject token")
+		}
+		return token, nil
+	case "text":
+		return string(tokenBytes), nil
+	case "":
+		return string(tokenBytes), nil
+	default:
+		return "", errors.New("oauth2/google: invalid credential_source file format type")
+	}
+
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/impersonate.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/impersonate.go
@@ -1,0 +1,98 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// generateAccesstokenReq is used for service account impersonation
+type generateAccessTokenReq struct {
+	Delegates []string `json:"delegates,omitempty"`
+	Lifetime  string   `json:"lifetime,omitempty"`
+	Scope     []string `json:"scope,omitempty"`
+}
+
+type impersonateTokenResponse struct {
+	AccessToken string `json:"accessToken"`
+	ExpireTime  string `json:"expireTime"`
+}
+
+// ImpersonateTokenSource uses a source credential, stored in Ts, to request an access token to the provided URL.
+// Scopes can be defined when the access token is requested.
+type ImpersonateTokenSource struct {
+	// Ctx is the execution context of the impersonation process
+	// used to perform http call to the URL. Required
+	Ctx context.Context
+	// Ts is the source credential used to generate a token on the
+	// impersonated service account. Required.
+	Ts oauth2.TokenSource
+
+	// URL is the endpoint to call to generate a token
+	// on behalf the service account. Required.
+	URL string
+	// Scopes that the impersonated credential should have. Required.
+	Scopes []string
+	// Delegates are the service account email addresses in a delegation chain.
+	// Each service account must be granted roles/iam.serviceAccountTokenCreator
+	// on the next service account in the chain. Optional.
+	Delegates []string
+}
+
+// Token performs the exchange to get a temporary service account token to allow access to GCP.
+func (its ImpersonateTokenSource) Token() (*oauth2.Token, error) {
+	reqBody := generateAccessTokenReq{
+		Lifetime:  "3600s",
+		Scope:     its.Scopes,
+		Delegates: its.Delegates,
+	}
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: unable to marshal request: %v", err)
+	}
+	client := oauth2.NewClient(its.Ctx, its.Ts)
+	req, err := http.NewRequest("POST", its.URL, bytes.NewReader(b))
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: unable to create impersonation request: %v", err)
+	}
+	req = req.WithContext(its.Ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: unable to generate access token: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: unable to read body: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("oauth2/google: status code %d: %s", c, body)
+	}
+
+	var accessTokenResp impersonateTokenResponse
+	if err := json.Unmarshal(body, &accessTokenResp); err != nil {
+		return nil, fmt.Errorf("oauth2/google: unable to parse response: %v", err)
+	}
+	expiry, err := time.Parse(time.RFC3339, accessTokenResp.ExpireTime)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: unable to parse expiry: %v", err)
+	}
+	return &oauth2.Token{
+		AccessToken: accessTokenResp.AccessToken,
+		Expiry:      expiry,
+		TokenType:   "Bearer",
+	}, nil
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/sts_exchange.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/sts_exchange.go
@@ -1,0 +1,107 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"golang.org/x/oauth2"
+)
+
+// exchangeToken performs an oauth2 token exchange with the provided endpoint.
+// The first 4 fields are all mandatory.  headers can be used to pass additional
+// headers beyond the bare minimum required by the token exchange.  options can
+// be used to pass additional JSON-structured options to the remote server.
+func exchangeToken(ctx context.Context, endpoint string, request *stsTokenExchangeRequest, authentication clientAuthentication, headers http.Header, options map[string]interface{}) (*stsTokenExchangeResponse, error) {
+
+	client := oauth2.NewClient(ctx, nil)
+
+	data := url.Values{}
+	data.Set("audience", request.Audience)
+	data.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	data.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	data.Set("subject_token_type", request.SubjectTokenType)
+	data.Set("subject_token", request.SubjectToken)
+	data.Set("scope", strings.Join(request.Scope, " "))
+	if options != nil {
+		opts, err := json.Marshal(options)
+		if err != nil {
+			return nil, fmt.Errorf("oauth2/google: failed to marshal additional options: %v", err)
+		}
+		data.Set("options", string(opts))
+	}
+
+	authentication.InjectAuthentication(data, headers)
+	encodedData := data.Encode()
+
+	req, err := http.NewRequest("POST", endpoint, strings.NewReader(encodedData))
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: failed to properly build http request: %v", err)
+
+	}
+	req = req.WithContext(ctx)
+	for key, list := range headers {
+		for _, val := range list {
+			req.Header.Add(key, val)
+		}
+	}
+	req.Header.Add("Content-Length", strconv.Itoa(len(encodedData)))
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: invalid response from Secure Token Server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("oauth2/google: status code %d: %s", c, body)
+	}
+	var stsResp stsTokenExchangeResponse
+	err = json.Unmarshal(body, &stsResp)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2/google: failed to unmarshal response body from Secure Token Server: %v", err)
+
+	}
+
+	return &stsResp, nil
+}
+
+// stsTokenExchangeRequest contains fields necessary to make an oauth2 token exchange.
+type stsTokenExchangeRequest struct {
+	ActingParty struct {
+		ActorToken     string
+		ActorTokenType string
+	}
+	GrantType          string
+	Resource           string
+	Audience           string
+	Scope              []string
+	RequestedTokenType string
+	SubjectToken       string
+	SubjectTokenType   string
+}
+
+// stsTokenExchangeResponse is used to decode the remote server response during an oauth2 token exchange.
+type stsTokenExchangeResponse struct {
+	AccessToken     string `json:"access_token"`
+	IssuedTokenType string `json:"issued_token_type"`
+	TokenType       string `json:"token_type"`
+	ExpiresIn       int    `json:"expires_in"`
+	Scope           string `json:"scope"`
+	RefreshToken    string `json:"refresh_token"`
+}

--- a/vendor/golang.org/x/oauth2/google/internal/externalaccount/urlcredsource.go
+++ b/vendor/golang.org/x/oauth2/google/internal/externalaccount/urlcredsource.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+type urlCredentialSource struct {
+	URL     string
+	Headers map[string]string
+	Format  format
+	ctx     context.Context
+}
+
+func (cs urlCredentialSource) subjectToken() (string, error) {
+	client := oauth2.NewClient(cs.ctx, nil)
+	req, err := http.NewRequest("GET", cs.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("oauth2/google: HTTP request for URL-sourced credential failed: %v", err)
+	}
+	req = req.WithContext(cs.ctx)
+
+	for key, val := range cs.Headers {
+		req.Header.Add(key, val)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("oauth2/google: invalid response when retrieving subject token: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("oauth2/google: invalid body in subject token URL query: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return "", fmt.Errorf("oauth2/google: status code %d: %s", c, respBody)
+	}
+
+	switch cs.Format.Type {
+	case "json":
+		jsonData := make(map[string]interface{})
+		err = json.Unmarshal(respBody, &jsonData)
+		if err != nil {
+			return "", fmt.Errorf("oauth2/google: failed to unmarshal subject token file: %v", err)
+		}
+		val, ok := jsonData[cs.Format.SubjectTokenFieldName]
+		if !ok {
+			return "", errors.New("oauth2/google: provided subject_token_field_name not found in credentials")
+		}
+		token, ok := val.(string)
+		if !ok {
+			return "", errors.New("oauth2/google: improperly formatted subject token")
+		}
+		return token, nil
+	case "text":
+		return string(respBody), nil
+	case "":
+		return string(respBody), nil
+	default:
+		return "", errors.New("oauth2/google: invalid credential_source file format type")
+	}
+
+}

--- a/vendor/golang.org/x/oauth2/google/jwt.go
+++ b/vendor/golang.org/x/oauth2/google/jwt.go
@@ -7,6 +7,7 @@ package google
 import (
 	"crypto/rsa"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -24,6 +25,28 @@ import (
 // optimization supported by a few Google services.
 // Unless you know otherwise, you should use JWTConfigFromJSON instead.
 func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.TokenSource, error) {
+	return newJWTSource(jsonKey, audience, nil)
+}
+
+// JWTAccessTokenSourceWithScope uses a Google Developers service account JSON
+// key file to read the credentials that authorize and authenticate the
+// requests, and returns a TokenSource that does not use any OAuth2 flow but
+// instead creates a JWT and sends that as the access token.
+// The scope is typically a list of URLs that specifies the scope of the
+// credentials.
+//
+// Note that this is not a standard OAuth flow, but rather an
+// optimization supported by a few Google services.
+// Unless you know otherwise, you should use JWTConfigFromJSON instead.
+func JWTAccessTokenSourceWithScope(jsonKey []byte, scope ...string) (oauth2.TokenSource, error) {
+	return newJWTSource(jsonKey, "", scope)
+}
+
+func newJWTSource(jsonKey []byte, audience string, scopes []string) (oauth2.TokenSource, error) {
+	if len(scopes) == 0 && audience == "" {
+		return nil, fmt.Errorf("google: missing scope/audience for JWT access token")
+	}
+
 	cfg, err := JWTConfigFromJSON(jsonKey)
 	if err != nil {
 		return nil, fmt.Errorf("google: could not parse JSON key: %v", err)
@@ -35,6 +58,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 	ts := &jwtAccessTokenSource{
 		email:    cfg.Email,
 		audience: audience,
+		scopes:   scopes,
 		pk:       pk,
 		pkID:     cfg.PrivateKeyID,
 	}
@@ -47,6 +71,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 
 type jwtAccessTokenSource struct {
 	email, audience string
+	scopes          []string
 	pk              *rsa.PrivateKey
 	pkID            string
 }
@@ -54,12 +79,14 @@ type jwtAccessTokenSource struct {
 func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
 	iat := time.Now()
 	exp := iat.Add(time.Hour)
+	scope := strings.Join(ts.scopes, " ")
 	cs := &jws.ClaimSet{
-		Iss: ts.email,
-		Sub: ts.email,
-		Aud: ts.audience,
-		Iat: iat.Unix(),
-		Exp: exp.Unix(),
+		Iss:   ts.email,
+		Sub:   ts.email,
+		Aud:   ts.audience,
+		Scope: scope,
+		Iat:   iat.Unix(),
+		Exp:   exp.Unix(),
 	}
 	hdr := &jws.Header{
 		Algorithm: "RS256",

--- a/vendor/golang.org/x/oauth2/internal/client_appengine.go
+++ b/vendor/golang.org/x/oauth2/internal/client_appengine.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build appengine
 // +build appengine
 
 package internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -273,9 +273,11 @@ golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
 golang.org/x/net/websocket
-# golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
+# golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 golang.org/x/oauth2
+golang.org/x/oauth2/authhandler
 golang.org/x/oauth2/google
+golang.org/x/oauth2/google/internal/externalaccount
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt


### PR DESCRIPTION
…ided for encryption

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #PWX-26307 [https://portworx.atlassian.net/browse/PWX-26307]

**Special notes for your reviewer**:
https://github.com/portworx/porx/pull/9762 has already been created to add support for disk encryption using customer managed key.

Customer should be able to provide Encrypt/Decrypt on their default gce account for disk encryption so that if device level kms account is not provided then 
1. if an account.json file has been updated in the pod via GOOGLE_APPLICATION_CREDENTIALS, that service account should be used as disk encryption kms account.
2. If deployement is using instance gce account, that service account should be used as disk encryption kms account.
