### PR TITLE
Fix Oracle IMDS metadata lookup for non-oracle instances

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -139,8 +139,11 @@ func getRequest(endpoint string, headers map[string]string) (map[string]interfac
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return metadata, resp.StatusCode,
-			fmt.Errorf("metadata lookup from [%s] endpoint failed with error:[%v]", endpoint, err)
+		errMsg := fmt.Errorf("metadata lookup from [%s] endpoint failed with error:[%v]", endpoint, err)
+		if resp != nil {
+			return metadata, resp.StatusCode, errMsg
+		}
+		return metadata, http.StatusNotFound, errMsg
 	}
 	if resp.StatusCode != http.StatusOK {
 		return metadata, resp.StatusCode, nil


### PR DESCRIPTION
On non-oracle instances, http client for IMDS endpoint returns nil response. This commit handles the nil response.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

