### PR TITLE
PWX-26383: Only log warning when instance service account is not extr…

### DIFF
--- a/gce/gce.go
+++ b/gce/gce.go
@@ -1240,11 +1240,11 @@ func gceInfo(ctx context.Context, inst *instance) error {
 	if content["client_email"] != nil {
 		inst.serviceAccount = fmt.Sprintf("%s", content["client_email"])
 	} else {
-		serviceAccount, err := metadata.Email("")
+		inst.serviceAccount, err = metadata.Email("")
 		if err != nil {
-			return fmt.Errorf("unable to get gce instance service account")
+			// No need to error out for non-GKE compute instances
+			logrus.Warnf("unable to get gce instance service account")
 		}
-		inst.serviceAccount = serviceAccount
 	}
 	return nil
 }


### PR DESCRIPTION
…acted in gke.

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>


**What this PR does / why we need it**:
To fix Porx travis test failure

**Which issue(s) this PR fixes** (optional)
Closes #PWX-26383

**Special notes for your reviewer**:
Following changes were done to add support of default account for disk encryption
https://github.com/libopenstorage/cloudops/commit/07ce5dd9b4ac7f3ecf608dfaafb396eec9d54d47#diff-85d719939b78e1f1935dc08be3b96f95eb802c1f7644748ed1256ce94a29c522

We expect this function to not return an error if we are invoking this in non gke context.
We have similar calls in the same function logging only a warning https://github.com/libopenstorage/cloudops/blob/master/gce/gce.go#:~:text=inst.clusterLocation%2C%20err,%7D

