### PR TITLE
[PWX-26478] Specified timeout for http client required for Oracle metadata lookup

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/libopenstorage/cloudops"
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -67,7 +68,6 @@ func NewClient() (cloudops.Ops, error) {
 	oracleOps := &oracleOps{}
 	err := getInfoFromMetadata(oracleOps)
 	if err != nil {
-		fmt.Printf("Got error [%v] from metadata\n", err)
 		err = getInfoFromEnv(oracleOps)
 		if err != nil {
 			return nil, err
@@ -130,7 +130,9 @@ func getInfoFromEnv(oracleOps *oracleOps) error {
 
 func getRequest(endpoint string, headers map[string]string) (map[string]interface{}, int, error) {
 	metadata := make(map[string]interface{})
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return metadata, 0, err


### PR DESCRIPTION
- Removed unwanted log statement. 
- Specified timeout for http client required for Oracle metadata lookup.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

