### PR TITLE
PWX-24574 : Add CloudOps API to delete OKE worker nodes

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -738,13 +738,13 @@ func (o *oracleOps) DeleteInstance(instanceID string, zone string, timeout time.
 		return err
 	}
 
-	var nodePoolId *string
+	var nodePoolID *string
 
 	switch len(pools.Items) {
 	case 0:
 		return errors.New("No node pool found ")
 	case 1:
-		nodePoolId = pools.Items[0].Id
+		nodePoolID = pools.Items[0].Id
 	default:
 		for _, pool := range pools.Items {
 			poolResp, err := o.containerEngine.GetNodePool(context.Background(), containerengine.GetNodePoolRequest{NodePoolId: pool.Id})
@@ -753,14 +753,14 @@ func (o *oracleOps) DeleteInstance(instanceID string, zone string, timeout time.
 			}
 			if ok := nodePoolContainsNode(poolResp.Nodes, instanceID); ok {
 				logrus.Println("Instance is in pool ", *pool.Name)
-				nodePoolId = pool.Id
+				nodePoolID = pool.Id
 				break
 			}
 		}
 	}
 
 	nodeDeleteReq := containerengine.DeleteNodeRequest{
-		NodePoolId:      nodePoolId,
+		NodePoolId:      nodePoolID,
 		NodeId:          &instanceID,
 		IsDecrementSize: common.Bool(false),
 	}


### PR DESCRIPTION
Jira Ticket : https://portworx.atlassian.net/browse/PWX-24574

Changes done : 
Implemented DeleteInstance API for OracleOps.

Tests done : 
Deletion of instances with single and multiple nodepools performed.
<img width="453" alt="image" src="https://user-images.githubusercontent.com/107468860/187850930-4e6c4c93-8e40-4076-91a1-7444c41d7c88.png">


