### PR TITLE
PWX-24702 : Add cloudOps API to upgrade OKE cluster

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -788,6 +788,7 @@ func nodePoolContainsNode(s []containerengine.Node, e string) bool {
 }
 
 func (o *oracleOps) SetClusterVersion(version string, timeout time.Duration) error {
+	logrus.Println("Setting Cluster version to", version)
 	req := containerengine.UpdateClusterRequest{
 		ClusterId: &o.clusterID,
 		UpdateClusterDetails: containerengine.UpdateClusterDetails{
@@ -804,9 +805,9 @@ func (o *oracleOps) SetClusterVersion(version string, timeout time.Duration) err
 }
 
 func (o *oracleOps) SetInstanceGroupVersion(instanceGroupName string, version string, timeout time.Duration) error {
-
+	logrus.Println("Setting Instance group version to", version)
 	//get nodepool ID from name
-	var instanceGroupId *string
+	var instanceGroupID *string
 	nodePoolsReq := containerengine.ListNodePoolsRequest{CompartmentId: &o.compartmentID, Name: &instanceGroupName, ClusterId: &o.clusterID}
 	nodePools, err := o.containerEngine.ListNodePools(context.Background(), nodePoolsReq)
 	if err != nil {
@@ -814,13 +815,13 @@ func (o *oracleOps) SetInstanceGroupVersion(instanceGroupName string, version st
 	}
 
 	if len(nodePools.Items) == 0 {
-		return errors.New("No node pool found with name " + instanceGroupName)
+		return errors.New("No node pool found with name" + instanceGroupName)
 	}
-	instanceGroupId = nodePools.Items[0].Id
+	instanceGroupID = nodePools.Items[0].Id
 
 	//update kubernetes version of nodepool
 	resp, err := o.containerEngine.UpdateNodePool(context.Background(), containerengine.UpdateNodePoolRequest{
-		NodePoolId: instanceGroupId,
+		NodePoolId: instanceGroupID,
 		UpdateNodePoolDetails: containerengine.UpdateNodePoolDetails{
 			KubernetesVersion: &version,
 		},
@@ -851,7 +852,6 @@ func (o *oracleOps) SetInstanceGroupVersion(instanceGroupName string, version st
 		nodePoolPlacementConfigDetails[i].AvailabilityDomain = placementConfigs.AvailabilityDomain
 		nodePoolPlacementConfigDetails[i].SubnetId = placementConfigs.SubnetId
 	}
-
 	//delete all nodes from existing node pool
 	if err := o.SetInstanceGroupSize(instanceGroupName, 0, timeout); err != nil {
 		return err
@@ -867,7 +867,7 @@ func (o *oracleOps) SetInstanceGroupVersion(instanceGroupName string, version st
 			},
 		},
 	}
-
+	logrus.Println("Creating nodes with version", version)
 	updateResp, err := o.containerEngine.UpdateNodePool(context.Background(), req)
 	if err != nil {
 		return err

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -859,7 +859,7 @@ func (o *oracleOps) SetInstanceGroupVersion(instanceGroupName string, version st
 
 	//create same number of nodes again with updated version
 	req := containerengine.UpdateNodePoolRequest{
-		NodePoolId: instanceGroupId, //get node pool id
+		NodePoolId: instanceGroupID, //get node pool id
 		UpdateNodePoolDetails: containerengine.UpdateNodePoolDetails{
 			NodeConfigDetails: &containerengine.UpdateNodePoolNodeConfigDetails{
 				Size:             &totalClusterSize,


### PR DESCRIPTION
Jira ticket : https://portworx.atlassian.net/browse/PWX-24702

Changes done : 
> Implemented SetClusterVersion API - update kubernetes version of the Cluster
> Implemented SetInstanceGroupVersion API - update kubernetes version of nodepool and all existing nodes

Tests Done : 
> Verified Upgrade scenarion from v1.21.5 to v1.24.1 in steps and by skipping steps, for cluster , nodepool and all nodes.