### PR TITLE
Removed additional devicePath lookup after Attaching the volume.

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -422,6 +422,10 @@ func (o *oracleOps) Create(template interface{}, labels map[string]string) (inte
 	}
 	createVolResp, err := o.storage.CreateVolume(context.Background(), createVolReq)
 	if err != nil {
+		if strings.Contains(err.Error(), "vpusPerGB is invalid") {
+			return nil, fmt.Errorf("VPUs must be an integer that is multiple of 10 " +
+				"Please refer to oracle cloud block volume documentation for valid values")
+		}
 		return nil, err
 	}
 

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -610,18 +610,22 @@ func (o *oracleOps) Attach(volumeID string, options map[string]string) (string, 
 			return "", err
 		}
 
+		var devicePath string
 		if attachVolResp.GetLifecycleState() != core.VolumeAttachmentLifecycleStateAttached {
-			err = o.waitVolumeAttachmentStatus(
+			devicePath, err = o.waitVolumeAttachmentStatus(
 				attachVolResp.GetId(),
 				core.VolumeAttachmentLifecycleStateAttached,
 			)
 			if err != nil {
-				return "", err
+				devicePath, err := o.DevicePath(volumeID)
+				if err != nil {
+					return "", err
+				}
+				o.volumeAttachmentMapping[volumeID] = attachVolResp.GetId()
+				return devicePath, err
 			}
-		}
-		devicePath, err := o.DevicePath(volumeID)
-		if err != nil {
-			logrus.Errorf("Error while getting device path. Error: %v", err)
+		} else {
+			devicePath = *attachVolResp.GetDevice()
 		}
 		o.volumeAttachmentMapping[volumeID] = attachVolResp.GetId()
 		return devicePath, err
@@ -629,7 +633,7 @@ func (o *oracleOps) Attach(volumeID string, options map[string]string) (string, 
 	return "", fmt.Errorf("failed to attach any of the free devices. Attempted: %v", devices)
 }
 
-func (o *oracleOps) waitVolumeAttachmentStatus(volumeAttachmentID *string, desiredStatus core.VolumeAttachmentLifecycleStateEnum) error {
+func (o *oracleOps) waitVolumeAttachmentStatus(volumeAttachmentID *string, desiredStatus core.VolumeAttachmentLifecycleStateEnum) (string, error) {
 	getVolAttachmentReq := core.GetVolumeAttachmentRequest{
 		VolumeAttachmentId: volumeAttachmentID,
 	}
@@ -639,14 +643,21 @@ func (o *oracleOps) waitVolumeAttachmentStatus(volumeAttachmentID *string, desir
 			return nil, true, err
 		}
 		if getVolAttachmentResp.GetLifecycleState() == desiredStatus {
-			return nil, false, nil
+			return getVolAttachmentResp.GetDevice(), false, nil
 		}
 
 		logrus.Debugf("volume [%s] is still in [%s] state", *getVolAttachmentResp.GetVolumeId(), getVolAttachmentResp.GetLifecycleState())
 		return nil, true, fmt.Errorf("volume [%s] is still in [%s] state", *getVolAttachmentResp.GetVolumeId(), getVolAttachmentResp.GetLifecycleState())
 	}
-	_, err := task.DoRetryWithTimeout(f, cloudops.ProviderOpsTimeout, cloudops.ProviderOpsRetryInterval)
-	return err
+	devicePathRaw, err := task.DoRetryWithTimeout(f, cloudops.ProviderOpsTimeout, cloudops.ProviderOpsRetryInterval)
+	if err != nil {
+		return "", err
+	}
+	devicePath, ok := devicePathRaw.(*string)
+	if !ok {
+		return "", fmt.Errorf("volume attachment [%s] attached successfully but could not get it's local device path", *volumeAttachmentID)
+	}
+	return *devicePath, err
 }
 
 // Detach volumeID.
@@ -690,7 +701,7 @@ func (o *oracleOps) detachInternal(volumeID, instanceID string) error {
 			volumeID, instanceID, detachVolResp, err)
 		return err
 	}
-	err = o.waitVolumeAttachmentStatus(
+	_, err = o.waitVolumeAttachmentStatus(
 		attachmentID,
 		core.VolumeAttachmentLifecycleStateDetached,
 	)
@@ -787,7 +798,6 @@ func nodePoolContainsNode(s []containerengine.Node, e string) bool {
 	}
 	return false
 }
-
 
 func (o *oracleOps) Expand(volumeID string, newSizeInGiB uint64) (uint64, error) {
 	logrus.Debug("Expand volume to size ", newSizeInGiB, " GiB")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

Below test passed:
```
go test -v .
=== RUN   TestAll
2022/09/15 07:25:41 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [PROVISIONING] state Next retry in: 3s
2022/09/15 07:25:44 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [PROVISIONING] state Next retry in: 3s
2022/09/15 07:25:48 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [PROVISIONING] state Next retry in: 3s
Created disk: { AvailabilityDomain=zSZL:US-SANJOSE-1-AD-1 CompartmentId=ocid1.compartment.oc1..aaaaaaaaxalgtzvncgpshcpiynag6aq5z36vwh63b3aaj63ay3ymkhxgprvq DisplayName=openstorage-test-d4c65356-2930-4c43-966a-906c079612ff Id=ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua LifecycleState=AVAILABLE SizeInMBs=51200 TimeCreated=2022-09-15 07:25:41.771 +0000 UTC DefinedTags=map[Oracle-Tags:map[CreatedBy:oracleidentitycloudservice/vshinde CreatedOn:2022-09-15T07:25:41.745Z]] FreeformTags=map[] SystemTags=map[] IsHydrated=true KmsKeyId=<nil> VpusPerGB=10 SizeInGBs=50 SourceDetails=<nil> VolumeGroupId=<nil> IsAutoTuneEnabled=false AutoTunedVpusPerGB=<nil> BlockVolumeReplicas=[] }
successfully tagd.2022/09/15 07:25:52 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:25:55 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:25:58 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:01 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:04 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:07 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
[ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] attached on path [/dev/oracleoci/oraclevdf]
2022/09/15 07:26:11 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:14 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:18 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:21 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:24 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:27 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:31 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:34 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [DETACHING] state Next retry in: 3s
2022/09/15 07:26:41 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:44 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:48 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:51 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:54 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
2022/09/15 07:26:57 volume [ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua] is still in [ATTACHING] state Next retry in: 3s
time="2022-09-15T07:27:00Z" level=info msg="disk: ocid1.volume.oc1.us-sanjose-1.abzwuljr6n3vsnjqk2sp75ryjnjkz27zzsw3by4agpigxxg6dpla5twpr5ua attached at: /dev/oracleoci/oraclevdf"
--- PASS: TestAll (79.41s)
PASS
ok      github.com/libopenstorage/cloudops/oracle       79.419s
```
