### PR TITLE
[PWX-27134] Filter out only disks whos lifecycleState is ATTACHED in DeviceMappings() for oracle.

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -331,12 +331,14 @@ func (o *oracleOps) DeviceMappings() (map[string]string, error) {
 		return m, err
 	}
 	for _, va := range volumeAttachmentResp.Items {
-		if va.GetDevice() != nil && va.GetVolumeId() != nil {
-			devicePath = *va.GetDevice()
-			volID = *va.GetVolumeId()
-		} else {
-			logrus.Warnf("Device path or volume id for [%+v] volume attachment not found", va)
-			continue
+		if va.GetLifecycleState() == core.VolumeAttachmentLifecycleStateAttached {
+			if va.GetDevice() != nil && va.GetVolumeId() != nil {
+				devicePath = *va.GetDevice()
+				volID = *va.GetVolumeId()
+			} else {
+				logrus.Warnf("Device path or volume id for [%+v] volume attachment not found", va)
+				continue
+			}
 		}
 		m[devicePath] = volID
 	}


### PR DESCRIPTION
Currently, `ListVolumeAttachments()` oracle SDK API returns all volume attachements including the ones that are currently detached. So, we need to filter out only ones which are in `ATTACHED` state.
Signed-off-by: Vinayak Shinde <vinayakshnd@gmail.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

