### PR TITLE
[PWX-24574] Added GetInstance() API for oracle cloud provider

### DIFF
--- a/cloudops.go
+++ b/cloudops.go
@@ -97,6 +97,8 @@ type Compute interface {
 	// InspectInstanceGroupForInstance inspects the instance group to which the
 	// cloud instance with given ID belongs
 	InspectInstanceGroupForInstance(instanceID string) (*InstanceGroupInfo, error)
+	// GetInstance returns cloud provider specific instance details
+	GetInstance(displayName string) (interface{}, error)
 	// SetInstanceGroupSize sets desired node count per availability zone
 	// for given instance group
 	SetInstanceGroupSize(instanceGroupID string,

--- a/unsupported/unsupported.go
+++ b/unsupported/unsupported.go
@@ -35,6 +35,12 @@ func (u *unsupportedCompute) InspectInstanceGroupForInstance(instanceID string) 
 	}
 }
 
+func (u *unsupportedCompute) GetInstance(displayName string) (interface{}, error) {
+	return nil, &cloudops.ErrNotSupported{
+		Operation: "GetInstance",
+	}
+}
+
 func (u *unsupportedCompute) SetInstanceGroupSize(instanceGroupID string,
 	count int64,
 	timeout time.Duration) error {


### PR DESCRIPTION
Signed-off-by: Vinayak Shinde <vinayakshnd@gmail.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

DeleteInstance() API for oracle provider requires oracle compute instance ID. For torpedo, previously there was no cloudops API which would fetch instance details (and ID) from given instance name (Torpedo tracks instance by instance name). This API will help torpedo to fetch instance ID from given instance name.