### PR TITLE
PWX-27769: Recognize all zone labels on vSphere and IBM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	google.golang.org/api v0.30.0
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.20.4
 	k8s.io/apimachinery v0.20.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0


### PR DESCRIPTION
      On IBM and vSphere providers, not all the following zone labels are
      recognized.
      This patch adds support to recognize zones in the below order of
      labels:
        topology.portworx.io
        px/zone (for backward compatibility)
        topology.kubernetes.io
        failure-domain.beta.kubernetes.io

Signed-off-by: Naveen Revanna <nrevanna@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

