### PR TITLE
Added decision matrix row for max disk size for Oracle block volumes

### DIFF
--- a/oracle/storagemanager/oracle_test.go
+++ b/oracle/storagemanager/oracle_test.go
@@ -126,11 +126,11 @@ func storageDistribution(t *testing.T) {
 			response: &cloudops.StorageDistributionResponse{
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
-						DriveCapacityGiB: 1250,
+						DriveCapacityGiB: 1500,
 						DriveType:        "pv-0",
 						InstancesPerZone: 3,
 						DriveCount:       1,
-						IOPS:             2500,
+						IOPS:             3000,
 					},
 				},
 			},

--- a/oracle/storagemanager/oracle_test.go
+++ b/oracle/storagemanager/oracle_test.go
@@ -126,11 +126,11 @@ func storageDistribution(t *testing.T) {
 			response: &cloudops.StorageDistributionResponse{
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
-						DriveCapacityGiB: 1500,
+						DriveCapacityGiB: 1250,
 						DriveType:        "pv-0",
 						InstancesPerZone: 3,
 						DriveCount:       1,
-						IOPS:             3000,
+						IOPS:             2500,
 					},
 				},
 			},

--- a/oracle/storagemanager/spec/generator.go
+++ b/oracle/storagemanager/spec/generator.go
@@ -19,6 +19,17 @@ func main() {
 	matrixRows := []cloudops.StorageDecisionMatrixRow{}
 	for vpu := 0; vpu <= 120; vpu = vpu + 10 {
 		matrixRows = append(matrixRows, getMatrixRows(vpu)...)
+		row := getCommonRow(0)
+		iopsPerGB, maxIopsPerVol, err := getIOPSdetails(vpu)
+		if err != nil {
+			panic(err)
+		}
+		row.DriveType = fmt.Sprintf("%s%d", vpusPrefix, vpu)
+		row.MinIOPS = uint64(maxIopsPerVol)
+		row.MaxIOPS = uint64(maxIopsPerVol)
+		row.MinSize = uint64(math.Ceil(float64(row.MaxIOPS) / float64(iopsPerGB)))
+		row.MaxSize = uint64(32768)
+		matrixRows = append(matrixRows, row)
 	}
 	matrix := cloudops.StorageDecisionMatrix{Rows: matrixRows}
 	if err := parser.NewStorageDecisionMatrixParser().MarshalToYaml(&matrix, oracleYamlPath); err != nil {
@@ -29,9 +40,8 @@ func main() {
 
 }
 
-func getMatrixRows(vpu int) []cloudops.StorageDecisionMatrixRow {
+func getIOPSdetails(vpu int) (int64, int64, error) {
 	var iopsPerGB, maxIopsPerVol int64
-	rows := []cloudops.StorageDecisionMatrixRow{}
 	switch vpu {
 	case 0:
 		iopsPerGB = 2
@@ -72,6 +82,17 @@ func getMatrixRows(vpu int) []cloudops.StorageDecisionMatrixRow {
 	case 120:
 		iopsPerGB = 225
 		maxIopsPerVol = 300000
+	default:
+		return 0, 0, fmt.Errorf("invalid vpu value [%d]", vpu)
+	}
+	return iopsPerGB, maxIopsPerVol, nil
+}
+
+func getMatrixRows(vpu int) []cloudops.StorageDecisionMatrixRow {
+	rows := []cloudops.StorageDecisionMatrixRow{}
+	iopsPerGB, maxIopsPerVol, err := getIOPSdetails(vpu)
+	if err != nil {
+		panic(err)
 	}
 	row := getCommonRow(0)
 

--- a/oracle/storagemanager/testspecs/oracle.yaml
+++ b/oracle/storagemanager/testspecs/oracle.yaml
@@ -66,6 +66,17 @@ rows:
   priority: 0
   thin_provisioning: false
   drive_type: pv-0
+- min_iops: 3000
+  max_iops: 3000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1500
+  max_size: 32768
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-0
 - min_iops: 0
   max_iops: 500
   instance_type: '*'
@@ -613,6 +624,17 @@ rows:
   region: '*'
   min_size: 409
   max_size: 417
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-10
+- min_iops: 25000
+  max_iops: 25000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 417
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-10
@@ -1713,6 +1735,17 @@ rows:
   region: '*'
   min_size: 660
   max_size: 667
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-20
+- min_iops: 50000
+  max_iops: 50000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 667
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-20
@@ -3363,6 +3396,17 @@ rows:
   region: '*'
   min_size: 828
   max_size: 834
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-30
+- min_iops: 75000
+  max_iops: 75000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 834
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-30
@@ -5563,6 +5607,17 @@ rows:
   region: '*'
   min_size: 948
   max_size: 953
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-40
+- min_iops: 100000
+  max_iops: 100000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 953
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-40
@@ -8313,6 +8368,17 @@ rows:
   region: '*'
   min_size: 1038
   max_size: 1042
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-50
+- min_iops: 125000
+  max_iops: 125000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1042
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-50
@@ -11613,6 +11679,17 @@ rows:
   region: '*'
   min_size: 1108
   max_size: 1112
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-60
+- min_iops: 150000
+  max_iops: 150000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1112
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-60
@@ -15463,6 +15540,17 @@ rows:
   region: '*'
   min_size: 1164
   max_size: 1167
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-70
+- min_iops: 175000
+  max_iops: 175000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1167
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-70
@@ -19863,6 +19951,17 @@ rows:
   region: '*'
   min_size: 1210
   max_size: 1213
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-80
+- min_iops: 200000
+  max_iops: 200000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1213
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-80
@@ -24813,6 +24912,17 @@ rows:
   region: '*'
   min_size: 1248
   max_size: 1250
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-90
+- min_iops: 225000
+  max_iops: 225000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1250
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-90
@@ -30313,6 +30423,17 @@ rows:
   region: '*'
   min_size: 1280
   max_size: 1283
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-100
+- min_iops: 250000
+  max_iops: 250000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1283
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-100
@@ -36363,6 +36484,17 @@ rows:
   region: '*'
   min_size: 1308
   max_size: 1310
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-110
+- min_iops: 275000
+  max_iops: 275000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1310
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-110
@@ -42963,6 +43095,17 @@ rows:
   region: '*'
   min_size: 1332
   max_size: 1334
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-120
+- min_iops: 300000
+  max_iops: 300000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1334
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-120

--- a/specs/decisionmatrix/oracle.yaml
+++ b/specs/decisionmatrix/oracle.yaml
@@ -66,6 +66,17 @@ rows:
   priority: 0
   thin_provisioning: false
   drive_type: pv-0
+- min_iops: 3000
+  max_iops: 3000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1500
+  max_size: 32768
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-0
 - min_iops: 0
   max_iops: 500
   instance_type: '*'
@@ -613,6 +624,17 @@ rows:
   region: '*'
   min_size: 409
   max_size: 417
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-10
+- min_iops: 25000
+  max_iops: 25000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 417
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-10
@@ -1713,6 +1735,17 @@ rows:
   region: '*'
   min_size: 660
   max_size: 667
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-20
+- min_iops: 50000
+  max_iops: 50000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 667
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-20
@@ -3363,6 +3396,17 @@ rows:
   region: '*'
   min_size: 828
   max_size: 834
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-30
+- min_iops: 75000
+  max_iops: 75000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 834
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-30
@@ -5563,6 +5607,17 @@ rows:
   region: '*'
   min_size: 948
   max_size: 953
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-40
+- min_iops: 100000
+  max_iops: 100000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 953
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-40
@@ -8313,6 +8368,17 @@ rows:
   region: '*'
   min_size: 1038
   max_size: 1042
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-50
+- min_iops: 125000
+  max_iops: 125000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1042
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-50
@@ -11613,6 +11679,17 @@ rows:
   region: '*'
   min_size: 1108
   max_size: 1112
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-60
+- min_iops: 150000
+  max_iops: 150000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1112
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-60
@@ -15463,6 +15540,17 @@ rows:
   region: '*'
   min_size: 1164
   max_size: 1167
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-70
+- min_iops: 175000
+  max_iops: 175000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1167
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-70
@@ -19863,6 +19951,17 @@ rows:
   region: '*'
   min_size: 1210
   max_size: 1213
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-80
+- min_iops: 200000
+  max_iops: 200000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1213
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-80
@@ -24813,6 +24912,17 @@ rows:
   region: '*'
   min_size: 1248
   max_size: 1250
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-90
+- min_iops: 225000
+  max_iops: 225000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1250
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-90
@@ -30313,6 +30423,17 @@ rows:
   region: '*'
   min_size: 1280
   max_size: 1283
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-100
+- min_iops: 250000
+  max_iops: 250000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1283
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-100
@@ -36363,6 +36484,17 @@ rows:
   region: '*'
   min_size: 1308
   max_size: 1310
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-110
+- min_iops: 275000
+  max_iops: 275000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1310
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-110
@@ -42963,6 +43095,17 @@ rows:
   region: '*'
   min_size: 1332
   max_size: 1334
+  priority: 0
+  thin_provisioning: false
+  drive_type: pv-120
+- min_iops: 300000
+  max_iops: 300000
+  instance_type: '*'
+  instance_max_drives: 8
+  instance_min_drives: 1
+  region: '*'
+  min_size: 1334
+  max_size: 32768
   priority: 0
   thin_provisioning: false
   drive_type: pv-120


### PR DESCRIPTION
This PR enables user to expand Oracle block volumes beyond Max IOPS disk size.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

