### PR TITLE
Volume check functionality

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -947,24 +947,24 @@ func isErrorModificationNotFound(err error) bool {
 	return strings.HasPrefix(err.Error(), awsErrorModificationNotFound)
 }
 
-func (s *awsOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+func (s *awsOps) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	modificationStateRequest := &ec2.DescribeVolumesModificationsInput{
 		VolumeIds: volumeIDs,
 	}
 	describeOutput, err := s.ec2.DescribeVolumesModifications(modificationStateRequest)
-	states := describeOutput.VolumesModifications
 	if err != nil {
 		// modification state not found, this indicates no change has occurred before.
 		if isErrorModificationNotFound(err) {
 			return true, nil
 		}
-		return false, fmt.Errorf("unable to get volumes' modification states: %v", err)
+		return false, fmt.Errorf("unable to get modification states for aws volumes: %v", err)
 	}
+	states := describeOutput.VolumesModifications
 
 	var state string
 	for i := 0; i < len(states); i++ {
 		if states[i] == nil || states[i].ModificationState == nil {
-			logrus.Infof("volume modification state is nil for volume id: %s", *volumeIDs[i])
+			logrus.Debugf("volume modification state is nil for volume id: %s", *volumeIDs[i])
 			continue
 		}
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -942,6 +942,42 @@ func (s *awsOps) detachInternal(volumeID, instanceName string, options map[strin
 	return err
 }
 
+func (s *awsOps) getVolumeModificationState(volumeID string) (string, error) {
+	modificationStateRequest := &ec2.DescribeVolumesModificationsInput{
+		VolumeIds: []*string{&volumeID},
+	}
+	describeOutput, err := s.ec2.DescribeVolumesModifications(modificationStateRequest)
+	if err != nil {
+		return "", err
+	}
+	volumeModifications := describeOutput.VolumesModifications
+	if len(volumeModifications) == 0 {
+		return "", nil
+	}
+
+	volumeModification := volumeModifications[len(volumeModifications)-1]
+	state := *volumeModification.ModificationState
+	return state, nil
+}
+
+func (s *awsOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	for i := 0; i < len(volumeIDs); i++ {
+		state, err := s.getVolumeModificationState(volumeIDs[i])
+		if err != nil {
+			return false, fmt.Errorf("unable to get modification state: #{err}. ")
+		}
+		// Empty string indicates there was no volume change
+		if state == "" {
+			return true, nil
+		}
+		if state == ec2.VolumeModificationStateModifying ||
+			state == ec2.VolumeModificationStateOptimizing {
+			return false, fmt.Errorf("the last modification has not fully completed. ")
+		}
+	}
+	return true, nil
+}
+
 func (s *awsOps) Expand(
 	volumeID string,
 	newSizeInGiB uint64,

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -964,7 +964,7 @@ func (s *awsOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	var state string
 	for i := 0; i < len(states); i++ {
 		if states[i] == nil || states[i].ModificationState == nil {
-			logrus.Infof("volume modification state is nil for volume id: %s", state, *volumeIDs[i])
+			logrus.Infof("volume modification state is nil for volume id: %s", *volumeIDs[i])
 			continue
 		}
 

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -580,9 +580,9 @@ func (a *azureOps) DeleteFrom(diskName, _ string) error {
 	return a.Delete(diskName, nil)
 }
 
-func (a *azureOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+func (a *azureOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
-		Operation: "IsVolumesReadyToExpand",
+		Operation: "azureOps.IsVolumesReadyToExpand",
 	}
 }
 

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -580,6 +580,12 @@ func (a *azureOps) DeleteFrom(diskName, _ string) error {
 	return a.Delete(diskName, nil)
 }
 
+func (a *azureOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "IsVolumesReadyToExpand",
+	}
+}
+
 func (a *azureOps) Expand(
 	diskName string,
 	newSizeInGiB uint64,

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -580,7 +580,7 @@ func (a *azureOps) DeleteFrom(diskName, _ string) error {
 	return a.Delete(diskName, nil)
 }
 
-func (a *azureOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+func (a *azureOps) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
 		Operation: "azureOps.IsVolumesReadyToExpand",
 	}

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -436,6 +436,12 @@ func (e *exponentialBackoff) DevicePath(volumeID string) (string, error) {
 	return devicePath, origErr
 }
 
+func (e *exponentialBackoff) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "IsVolumesReadyToExpand",
+	}
+}
+
 func (e *exponentialBackoff) Expand(volumeID string, targetSize uint64, options map[string]string) (uint64, error) {
 	var (
 		actualSize uint64

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -440,7 +440,6 @@ func (e *exponentialBackoff) IsVolumesReadyToExpand(volumeIDs []*string) (bool, 
 	return e.cloudOps.IsVolumesReadyToExpand(volumeIDs)
 }
 
-
 func (e *exponentialBackoff) Expand(volumeID string, targetSize uint64, options map[string]string) (uint64, error) {
 	var (
 		actualSize uint64

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -436,11 +436,10 @@ func (e *exponentialBackoff) DevicePath(volumeID string) (string, error) {
 	return devicePath, origErr
 }
 
-func (e *exponentialBackoff) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
-	return true, &cloudops.ErrNotSupported{
-		Operation: "IsVolumesReadyToExpand",
-	}
+func (e *exponentialBackoff) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return e.cloudOps.IsVolumesReadyToExpand(volumeIDs)
 }
+
 
 func (e *exponentialBackoff) Expand(volumeID string, targetSize uint64, options map[string]string) (uint64, error) {
 	var (

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -436,8 +436,8 @@ func (e *exponentialBackoff) DevicePath(volumeID string) (string, error) {
 	return devicePath, origErr
 }
 
-func (e *exponentialBackoff) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
-	return e.cloudOps.IsVolumesReadyToExpand(volumeIDs)
+func (e *exponentialBackoff) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+	return e.cloudOps.AreVolumesReadyToExpand(volumeIDs)
 }
 
 func (e *exponentialBackoff) Expand(volumeID string, targetSize uint64, options map[string]string) (uint64, error) {

--- a/cloudops.go
+++ b/cloudops.go
@@ -129,6 +129,9 @@ type Storage interface {
 	// Attach volumeID, accepts attachoOptions as opaque data
 	// Return attach path.
 	Attach(volumeID string, options map[string]string) (string, error)
+	// IsVolumeReadyToExpand pre-checks if the volume is in a state that can be modified. Should be called
+	// before issue an expand request to the cloud provider
+	IsVolumesReadyToExpand(volumeIDs []string) (bool, error)
 	// Expand expands the provided device from the existing size to the new size
 	// It returns the new size of the device. It is a blocking API where it will
 	// only return once the requested size is validated with the cloud provider or

--- a/cloudops.go
+++ b/cloudops.go
@@ -131,7 +131,7 @@ type Storage interface {
 	Attach(volumeID string, options map[string]string) (string, error)
 	// IsVolumeReadyToExpand pre-checks if the volume is in a state that can be modified. Should be called
 	// before issue an expand request to the cloud provider
-	IsVolumesReadyToExpand(volumeIDs []string) (bool, error)
+	IsVolumesReadyToExpand(volumeIDs []*string) (bool, error)
 	// Expand expands the provided device from the existing size to the new size
 	// It returns the new size of the device. It is a blocking API where it will
 	// only return once the requested size is validated with the cloud provider or

--- a/cloudops.go
+++ b/cloudops.go
@@ -129,8 +129,8 @@ type Storage interface {
 	// Attach volumeID, accepts attachoOptions as opaque data
 	// Return attach path.
 	Attach(volumeID string, options map[string]string) (string, error)
-	// IsVolumeReadyToExpand pre-checks if the volume is in a state that can be modified. Should be called
-	// before issue an expand request to the cloud provider
+	// IsVolumeReadyToExpand pre-checks if a pool of volumes are in a state that can
+	// be modified. Should be called before sending an expand request to the cloud provider.
 	IsVolumesReadyToExpand(volumeIDs []*string) (bool, error)
 	// Expand expands the provided device from the existing size to the new size
 	// It returns the new size of the device. It is a blocking API where it will

--- a/cloudops.go
+++ b/cloudops.go
@@ -131,7 +131,7 @@ type Storage interface {
 	Attach(volumeID string, options map[string]string) (string, error)
 	// IsVolumeReadyToExpand pre-checks if a pool of volumes are in a state that can
 	// be modified. Should be called before sending an expand request to the cloud provider.
-	IsVolumesReadyToExpand(volumeIDs []*string) (bool, error)
+	AreVolumesReadyToExpand(volumeIDs []*string) (bool, error)
 	// Expand expands the provided device from the existing size to the new size
 	// It returns the new size of the device. It is a blocking API where it will
 	// only return once the requested size is validated with the cloud provider or

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -664,6 +664,11 @@ func (s *gceOps) GetDeviceID(disk interface{}) (string, error) {
 	}
 }
 
+func (s *gceOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "IsVolumesReadyToExpand",
+	}
+}
 func (s *gceOps) Expand(
 	volumeID string,
 	newSizeInGiB uint64,

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -664,7 +664,7 @@ func (s *gceOps) GetDeviceID(disk interface{}) (string, error) {
 	}
 }
 
-func (s *gceOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+func (s *gceOps) AreVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
 		Operation: "gceOps:IsVolumesReadyToExpand",
 	}

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -664,9 +664,9 @@ func (s *gceOps) GetDeviceID(disk interface{}) (string, error) {
 	}
 }
 
-func (s *gceOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+func (s *gceOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
-		Operation: "IsVolumesReadyToExpand",
+		Operation: "gceOps:IsVolumesReadyToExpand",
 	}
 }
 func (s *gceOps) Expand(

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -669,6 +669,7 @@ func (s *gceOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 		Operation: "gceOps:IsVolumesReadyToExpand",
 	}
 }
+
 func (s *gceOps) Expand(
 	volumeID string,
 	newSizeInGiB uint64,

--- a/mock/cloudops.mock.go
+++ b/mock/cloudops.mock.go
@@ -359,7 +359,7 @@ func (mr *MockOpsMockRecorder) InstanceID() *gomock.Call {
 }
 
 // IsVolumesReadyToExpand mocks base method.
-func (m *MockOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
+func (m *MockOps) IsVolumesReadyToExpand(arg0 []*string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsVolumesReadyToExpand", arg0)
 	ret0, _ := ret[0].(bool)

--- a/mock/cloudops.mock.go
+++ b/mock/cloudops.mock.go
@@ -358,6 +358,21 @@ func (mr *MockOpsMockRecorder) InstanceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockOps)(nil).InstanceID))
 }
 
+// IsVolumesReadyToExpand mocks base method.
+func (m *MockOps) IsVolumesReadyToExpand(arg0 []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsVolumesReadyToExpand", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsVolumesReadyToExpand indicates an expected call of IsVolumesReadyToExpand.
+func (mr *MockOpsMockRecorder) IsVolumesReadyToExpand(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVolumesReadyToExpand", reflect.TypeOf((*MockOps)(nil).IsVolumesReadyToExpand), arg0)
+}
+
 // Name mocks base method.
 func (m *MockOps) Name() string {
 	m.ctrl.T.Helper()

--- a/mock/cloudops.mock.go
+++ b/mock/cloudops.mock.go
@@ -359,7 +359,7 @@ func (mr *MockOpsMockRecorder) InstanceID() *gomock.Call {
 }
 
 // IsVolumesReadyToExpand mocks base method.
-func (m *MockOps) IsVolumesReadyToExpand(arg0 []string) (bool, error) {
+func (m *MockOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsVolumesReadyToExpand", arg0)
 	ret0, _ := ret[0].(bool)

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -293,7 +293,7 @@ func (o *oracleOps) GetInstance(displayName string) (interface{}, error) {
 	if len(listInstanceResp.Items) == 0 {
 		return nil, fmt.Errorf("no oracle instance found with display name: %s", displayName)
 	}
-	// Currently, torpedo uses this API to fetch details of the instance created 
+	// Currently, torpedo uses this API to fetch details of the instance created
 	// by OKE. OKE ensures that all the worker nodes created, have unique display
 	// names. In future, if we require to use this API to get details of vanilla
 	// compute instances, then we can modify below array indexing.
@@ -827,6 +827,12 @@ func nodePoolContainsNode(s []containerengine.Node, e string) bool {
 		}
 	}
 	return false
+}
+
+func (o *oracleOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "IsVolumesReadyToExpand",
+	}
 }
 
 func (o *oracleOps) Expand(volumeID string, newSizeInGiB uint64, options map[string]string) (uint64, error) {

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -829,9 +829,9 @@ func nodePoolContainsNode(s []containerengine.Node, e string) bool {
 	return false
 }
 
-func (o *oracleOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+func (o *oracleOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
-		Operation: "IsVolumesReadyToExpand",
+		Operation: "oracleOps:IsVolumesReadyToExpand",
 	}
 }
 

--- a/unsupported/unsupported.go
+++ b/unsupported/unsupported.go
@@ -99,6 +99,13 @@ func (u *unsupportedStorage) Attach(volumeID string, options map[string]string) 
 		Operation: "Attach",
 	}
 }
+
+func (u *unsupportedStorage) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "IsVolumesReadyToExpand",
+	}
+}
+
 func (u *unsupportedStorage) Expand(volumeID string, newSizeInGiB uint64, options map[string]string) (uint64, error) {
 	return 0, &cloudops.ErrNotSupported{
 		Operation: "Expand",

--- a/unsupported/unsupported.go
+++ b/unsupported/unsupported.go
@@ -100,9 +100,9 @@ func (u *unsupportedStorage) Attach(volumeID string, options map[string]string) 
 	}
 }
 
-func (u *unsupportedStorage) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+func (u *unsupportedStorage) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
-		Operation: "IsVolumesReadyToExpand",
+		Operation: "unsupportedStorage:IsVolumesReadyToExpand",
 	}
 }
 

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -476,7 +476,7 @@ func (ops *vsphereOps) DeviceMappings() (map[string]string, error) {
 			if ok {
 				diskUUID, err := vmObj.Datacenter.GetVirtualDiskPage83Data(ctx, backing.FileName)
 				if err != nil {
-					vmName,_ := vmObj.ObjectName(ctx)
+					vmName, _ := vmObj.ObjectName(ctx)
 					return nil, fmt.Errorf("failed to get device path for disk: %s on vm: %s err: %s", backing.FileName, vmName, err)
 				}
 
@@ -530,6 +530,12 @@ func (ops *vsphereOps) Enumerate(volumeIds []*string,
 ) (map[string][]interface{}, error) {
 	return nil, &cloudops.ErrNotSupported{
 		Operation: "Enumerate",
+	}
+}
+
+func (ops *vsphereOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+	return true, &cloudops.ErrNotSupported{
+		Operation: "IsVolumesReadyToExpand",
 	}
 }
 

--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -533,9 +533,9 @@ func (ops *vsphereOps) Enumerate(volumeIds []*string,
 	}
 }
 
-func (ops *vsphereOps) IsVolumesReadyToExpand(volumeIDs []string) (bool, error) {
+func (ops *vsphereOps) IsVolumesReadyToExpand(volumeIDs []*string) (bool, error) {
 	return true, &cloudops.ErrNotSupported{
-		Operation: "IsVolumesReadyToExpand",
+		Operation: "vsphereOps:IsVolumesReadyToExpand",
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
ebs volumes experience four states on modification, see
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-volume-modifications.html

This pull request addresses an issue where a user attempts to expand a storage pool while aws has not yet completed the optimization process for the associated volume(s), which leads to a pool expand failure. By implementing a checker function for this scenario, we aim to catch the said scenario early and provide a clear and readable error message to the user. 

**Which issue(s) this PR fixes** (optional)
PWX-28287

**Special notes for your reviewer**:
https://github.com/portworx/porx/pull/10496
