### PR TITLE
PWX-29069: Handling panic in case of incorrect volume template

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -371,7 +371,7 @@ func (a *azureOps) Create(
 	options map[string]string,
 ) (interface{}, error) {
 	d, ok := template.(*compute.Disk)
-	if !ok {
+	if !ok || d.DiskProperties == nil || d.DiskProperties.DiskSizeGB == nil {
 		return nil, cloudops.NewStorageError(
 			cloudops.ErrVolInval,
 			"Invalid volume template given",


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:
Handling panic due to nil DiskProperties when no param is specified in -s

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PWX-29069

**Special notes for your reviewer**:
* Issue is fixed after updating the volume template but we should handle this panic.
* This was caused when trying to dereference d.DiskProperties.DiskSizeGB
