### PR TITLE
PWX-29976: Datastore recommendation in vSphere 8

### DIFF
--- a/vsphere/vsphere.go
+++ b/vsphere/vsphere.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	vSphereDataStoreLock = "vsphere-ds-lock"
+	configProperty       = "config.hardware"
 )
 
 type vsphereOps struct {
@@ -818,6 +819,16 @@ func recommendDatastore(
 	}
 
 	resourcePoolRef := resourcePool.Reference()
+	var o mo.VirtualMachine
+	err = vmObj.Properties(ctx, vmObj.Reference(), []string{configProperty}, &o)
+	if err != nil || o.Config == nil {
+		// In case of an error defaulting to 4 CPUs and 8GB
+		spec.NumCPUs = 4
+		spec.MemoryMB = 8 * 1024
+	} else {
+		spec.NumCPUs = o.Config.Hardware.NumCPU
+		spec.MemoryMB = int64(o.Config.Hardware.MemoryMB)
+	}
 
 	sps := types.StoragePlacementSpec{
 		Type:             string(types.StoragePlacementSpecPlacementTypeCreate),


### PR DESCRIPTION
    vSphere 8.0 is making it mandatory to specify NumCPUs and MemoryMB.
This was stopping px from coming up on such cluster. This patch fixes it.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

