### PR TITLE
PWX-29108 : Handle nil pointer dereference in cloudops

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -298,6 +298,10 @@ func (s *awsOps) InspectInstanceGroupForInstance(instanceID string) (*cloudops.I
 			}
 
 			group := result.AutoScalingGroups[0]
+			if group == nil {
+				return nil, fmt.Errorf("nil AutoScalingGroups group")
+			}
+
 			zones := make([]string, 0)
 			for _, z := range group.AvailabilityZones {
 				zones = append(zones, *z)
@@ -796,7 +800,30 @@ func (s *awsOps) Create(
 		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
 			"Drive type not specified in the storage spec", "")
 	}
-
+	if vol.AvailabilityZone == nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"AvailabilityZone not specified in the storage spec", "")
+	}
+	if vol.Encrypted == nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"Encrypted not specified in the storage spec", "")
+	}
+	if vol.KmsKeyId == nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"KmsKeyId not specified in the storage spec", "")
+	}
+	if vol.Size == nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"Size not specified in the storage spec", "")
+	}
+	if vol.SnapshotId == nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"SnapshotId not specified in the storage spec", "")
+	}
+	if vol.Throughput == nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"Throughput not specified in the storage spec", "")
+	}
 	req := &ec2.CreateVolumeInput{
 		AvailabilityZone: vol.AvailabilityZone,
 		Encrypted:        vol.Encrypted,
@@ -992,6 +1019,14 @@ func (s *awsOps) Expand(
 	vol, err := s.refreshVol(&volumeID)
 	if err != nil {
 		return 0, err
+	}
+	if vol.Size == nil {
+		return 0, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"Size not specified in the storage spec", "")
+	}
+	if vol.VolumeId == nil {
+		return 0, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"VolumeId not specified in the storage spec", "")
 	}
 	currentSizeInGiB := uint64(*vol.Size)
 	if currentSizeInGiB >= newSizeInGiB {

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -371,14 +371,41 @@ func (a *azureOps) Create(
 	options map[string]string,
 ) (interface{}, error) {
 	d, ok := template.(*compute.Disk)
-	if !ok || d.DiskProperties == nil || d.DiskProperties.DiskSizeGB == nil {
+	if !ok || d.DiskProperties == nil{
 		return nil, cloudops.NewStorageError(
 			cloudops.ErrVolInval,
 			"Invalid volume template given",
 			a.instance,
 		)
 	}
-
+	if  d.DiskProperties.DiskIOPSReadWrite == nil{
+		return nil, cloudops.NewStorageError(
+			cloudops.ErrVolInval,
+			"DiskIOPSReadWrite not specified in the storage spec",
+			a.instance,
+		)
+	}
+	if  d.DiskProperties.DiskMBpsReadWrite == nil{
+		return nil, cloudops.NewStorageError(
+			cloudops.ErrVolInval,
+			"DiskMBpsReadWrite not specified in the storage spec",
+			a.instance,
+		)
+	}
+	if  d.DiskProperties.EncryptionSettingsCollection == nil{
+		return nil, cloudops.NewStorageError(
+			cloudops.ErrVolInval,
+			"EncryptionSettingsCollection not specified in the storage spec",
+			a.instance,
+		)
+	}
+	if  d.DiskProperties.Encryption == nil{
+		return nil, cloudops.NewStorageError(
+			cloudops.ErrVolInval,
+			"Encryption not specified in the storage spec",
+			a.instance,
+		)
+	}
 	// Check if the disk already exists; return err if it does
 	_, err := a.disksClient.Get(
 		context.Background(),

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -431,7 +431,22 @@ func (o *oracleOps) Create(template interface{}, labels map[string]string, optio
 		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
 			"Invalid volume template given", "")
 	}
-
+	if vol.SizeInGBs != nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"SizeInGBs type not specified in the storage spec", "")
+	}
+	if vol.VpusPerGB != nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"VpusPerGB type not specified in the storage spec", "")
+	}
+	if vol.DisplayName != nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"DisplayName type not specified in the storage spec", "")
+	}
+	if vol.KmsKeyId != nil {
+		return nil, cloudops.NewStorageError(cloudops.ErrVolInval,
+			"KmsKeyId type not specified in the storage spec", "")
+	}
 	createVolReq := core.CreateVolumeRequest{
 		CreateVolumeDetails: core.CreateVolumeDetails{
 			CompartmentId:      &o.compartmentID,


### PR DESCRIPTION
**What this PR does / why we need it**:
Following issue was reported on gs-rel 2.13 on Azure [PWX-29069](https://portworx.atlassian.net/browse/PWX-29069). This was related to nil drive size being passed during drive create which was resulting into nil pointer dereference.  This was fixed for Azure.

We need to do a thorough check on all the supported cloud platforms supported in cloudops for all the params that can be passed as “nil” that can result into a panic and handle those.

**Which issue(s) this PR fixes**
[PWX-29018](https://portworx.atlassian.net/browse/PWX-29108)

**Special notes for your reviewer**:
Workflow
- Scan the entire repo for different cloudops
- Add nil check for potential nil parameters. 
- Report corresponding error logs.

