### PR TITLE
PWX-30114: Handling error in store_kv

### DIFF
--- a/store/store_kv.go
+++ b/store/store_kv.go
@@ -90,6 +90,9 @@ func (kv *kvStore) getFullLockPath(key string) string {
 func (kv *kvStore) LockWithKey(owner, key string) (*Lock, error) {
 	fullPath := kv.getFullLockPath(key)
 	kvPair, err := kv.lockWithKeyHelper(owner, fullPath)
+	if err != nil {
+		return nil, err
+	}
 	kvPair.lockedWithKey = true
 	return kvPair, err
 }


### PR DESCRIPTION
    When a lock reaches tryDuration, it returns and error
    that the key already exists. It was not being returned.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Testing:
Was able to bring up px on nomad without a panic
