### PR TITLE
[PWX-32612] update the decisionmatrix for Vsphere LazyZeroThick & Eagerzeroedthick disk

### DIFF
--- a/specs/decisionmatrix/vsphere.yaml
+++ b/specs/decisionmatrix/vsphere.yaml
@@ -120,7 +120,7 @@ rows:
     instance_min_drives: 1
     instance_max_drives: 12
     region: "*"
-    min_size: 150
+    min_size: 100
     max_size: 500
     priority: 0
     thin_provisioning: true
@@ -174,7 +174,7 @@ rows:
     instance_min_drives: 1
     instance_max_drives: 12
     region: "*"
-    min_size: 150
+    min_size: 100
     max_size: 500
     priority: 0
     thin_provisioning: false


### PR DESCRIPTION
Vsphere LazyZeroThick & eagerzeroedthick disk cannot expand size between 100 to 150

[PWX-32612](https://portworx.atlassian.net/browse/PWX-32612
)
