### PR TITLE
PWX-32920: increase max size from 8192 to 63488

### DIFF
--- a/specs/decisionmatrix/vsphere.yaml
+++ b/specs/decisionmatrix/vsphere.yaml
@@ -49,7 +49,7 @@ rows:
     instance_max_drives: 12
     region: "*"
     min_size: 4096
-    max_size: 8192
+    max_size: 63488
     priority: 0
     thin_provisioning: true
     drive_type: "thin"
@@ -103,7 +103,7 @@ rows:
     instance_max_drives: 12
     region: "*"
     min_size: 4096
-    max_size: 8192
+    max_size: 63488
     priority: 0
     thin_provisioning: true
     drive_type: "zeroedthick"
@@ -157,7 +157,7 @@ rows:
     instance_max_drives: 12
     region: "*"
     min_size: 4096
-    max_size: 8192
+    max_size: 63488
     priority: 0
     thin_provisioning: true
     drive_type: "eagerzeroedthick"
@@ -211,7 +211,7 @@ rows:
     instance_max_drives: 12
     region: "*"
     min_size: 4096
-    max_size: 8192
+    max_size: 63488
     priority: 0
     thin_provisioning: false
     drive_type: "lazyzeroedthick"


### PR DESCRIPTION
Testing result: 
```
[root@ip-10-13-196-182 ~]# pxctl sv pool show
PX drive configuration:
Pool ID: 0
	Type:  Default
	UUID:  3c069a6d-4dd0-4ace-acf3-738acfe1aa7e
	IO Priority:  HIGH
	Labels:  kubernetes.io/hostname=ip-10-13-196-182.pwx.purestorage.com,topology.portworx.io/node=420338ef-bfb8-7aab-65ca-e7560aa8994f,kubernetes.io/os=linux,topology.portworx.io/datacenter=slc5-n5-CNBU,medium=STORAGE_MEDIUM_SSD,beta.kubernetes.io/arch=amd64,kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,topology.portworx.io/hypervisor=HostSystem-host-230,iopriority=HIGH
	Size: 47 GiB
	Status: Online
	Has metadata:  Yes
	Drives:
	1: /dev/sdf2, Total size 47 GiB, Online
	LastOperation  OPERATION_RESIZE
		Status:  OPERATION_PENDING
		Message: resize request from 50465865728 to 16106127360000 has been received
	Cache Drives:
	No Cache drives found in this pool
Journal Device:
	1: /dev/sdf1, STORAGE_MEDIUM_SSD
[root@ip-10-13-196-182 ~]# pxctl sv pool show
PX drive configuration:
Pool ID: 0
	Type:  Default
	UUID:  3c069a6d-4dd0-4ace-acf3-738acfe1aa7e
	IO Priority:  HIGH
	Labels:  beta.kubernetes.io/os=linux,topology.portworx.io/node=420338ef-bfb8-7aab-65ca-e7560aa8994f,kubernetes.io/hostname=ip-10-13-196-182.pwx.purestorage.com,topology.portworx.io/datacenter=slc5-n5-CNBU,kubernetes.io/os=linux,iopriority=HIGH,topology.portworx.io/hypervisor=HostSystem-host-230,medium=STORAGE_MEDIUM_SSD,kubernetes.io/arch=amd64,beta.kubernetes.io/arch=amd64
	Size: 15 TiB
	Status: Online
	Has metadata:  Yes
	Drives:
	1: /dev/sdf2, Total size 15 TiB, Online
	LastOperation  OPERATION_RESIZE
		Status:  OPERATION_SUCCESSFUL
		Message: pool expansion to 15000 GiB completed successfully
	Cache Drives:
	No Cache drives found in this pool
Journal Device:
	1: /dev/sdf1, STORAGE_MEDIUM_SSD
```