### PR TITLE
[PWX-35366][Oracle] Fixed DevicePath() API for Oracle cloud.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.17.x
+  - 1.18.x
 cache:
   directories:
     - $GOPATH/pkg/mod

--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,8 @@ const (
 	// ErrDiskGreaterOrEqualToExpandSize is code when a volume/disk expansion call fails
 	// as the given disk is already at a size greater than or equal to requested size
 	ErrDiskGreaterOrEqualToExpandSize
+	// ErrVolumeAttachedOnMultipleNodes is code when a volume is attached to multiple nodes
+	ErrVolumeAttachedOnMultipleNodes
 )
 
 // ErrNotFound is error type when an object of Type with ID is not found
@@ -115,9 +117,9 @@ func (e *ErrCurrentCapacityHigherThanDesired) Error() string {
 
 // ErrCloudProviderRequestFailure is returned when an unknown API request failure occurred.
 type ErrCloudProviderRequestFailure struct {
-    // Request is the API function name
+	// Request is the API function name
 	Request string
-    // Message is the error message returned by the cloud provider
+	// Message is the error message returned by the cloud provider
 	Message string
 }
 

--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -435,7 +435,6 @@ func (o *oracleOps) DevicePath(volumeID string) (string, error) {
 					fmt.Sprintf("Volume %s is attached to multiple instances: [%s] and [%s]",
 						volumeID, attachedInstanceID, *va.GetInstanceId()), "")
 			}
-			break
 		}
 	}
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently, cloudops only looks at the first volumeattachment from list of volumeattachements for a given volume in order to get its device path. But in case of failovers, (ie. existing storage node is deleted), same volume gets attached to new node creating a new volumeattachment which exists along with old volumeattachment for old node (in DETACHED state).

With this new PR, cloudops will go through list of all volumeattachements for a given volume and will use volumeattachement  obj that is in ATTACHED state to find out device path.

**Which issue(s) this PR fixes** (optional)
Closes #
https://portworx.atlassian.net/browse/PWX-35366

**Special notes for your reviewer**:

**Scenario 1: When device is detached.**

<img width="815" alt="Screenshot 2023-12-13 at 7 13 59 PM" src="https://github.com/libopenstorage/cloudops/assets/4953411/152c958b-9c5e-46be-8345-364a88d87ffd">


```
[opc@oke-cii3qdqu64q-nxlffs5mlra-sraq6gvhj3a-0 oracle]$ go test -v .
=== RUN   TestAll
    cloudops.go:336: 
                Error Trace:    /home/opc/go/src/github.com/libopenstorage/cloudops/oracle/cloudops.go:336
                                                        /home/opc/go/src/github.com/libopenstorage/cloudops/oracle/cloudops.go:59
                                                        /home/opc/go/src/github.com/libopenstorage/cloudops/oracle/oracle_test.go:49
                Error:          Received unexpected error:
                                Volume is detached
                Test:           TestAll
                Messages:       get device path returned error
--- FAIL: TestAll (0.11s)
FAIL
FAIL    github.com/libopenstorage/cloudops/oracle       0.118s
FAIL
```

**Scenario 2: Device attached to an different instance (remote/ instance other than where code is running)**

<img width="957" alt="Screenshot 2023-12-13 at 7 17 19 PM" src="https://github.com/libopenstorage/cloudops/assets/4953411/8662136e-5770-4e02-8b92-fcc86b662eec">

```
[opc@oke-cii3qdqu64q-nxlffs5mlra-sraq6gvhj3a-0 oracle]$ go test -v .
=== RUN   TestAll
    cloudops.go:336: 
                Error Trace:    /home/opc/go/src/github.com/libopenstorage/cloudops/oracle/cloudops.go:336
                                                        /home/opc/go/src/github.com/libopenstorage/cloudops/oracle/cloudops.go:59
                                                        /home/opc/go/src/github.com/libopenstorage/cloudops/oracle/oracle_test.go:49
                Error:          Received unexpected error:
                                Volume attached on "ocid1.instance.oc1.iad.anuwcljrxypu2kicvjypaug4uimrnqlr4jis7nwg2g6uj4ad2ua3vxp3fc7a" current instance "ocid1.instance.oc1.iad.anuwcljsxypu2kicdj2jz4qvep7sfarg5f5senbzqjlhca7gy7szol4sm3va"
                Test:           TestAll
                Messages:       get device path returned error
--- FAIL: TestAll (0.32s)
FAIL
FAIL    github.com/libopenstorage/cloudops/oracle       0.332s
FAIL
```

**Scenario 3: Device attached on the same/local node where code is running.**

<img width="967" alt="Screenshot 2023-12-13 at 7 26 09 PM" src="https://github.com/libopenstorage/cloudops/assets/4953411/13a6ff10-8ef1-4e4f-8992-d0416def0132">


```
[opc@oke-cii3qdqu64q-nxlffs5mlra-sraq6gvhj3a-0 oracle]$ go test -v .
=== RUN   TestAll
time="2023-12-13T13:54:15Z" level=info msg="disk: ocid1.volume.oc1.iad.abuwcljs3m3r5tudbxk5rdkeddni5bk47jrk66fn4jzdbin4lderucxfu4vq device path is: /dev/oracleoci/oraclevdb"
--- PASS: TestAll (0.10s)
PASS
ok      github.com/libopenstorage/cloudops/oracle       0.112s
[opc@oke-cii3qdqu64q-nxlffs5mlra-sraq6gvhj3a-0 oracle]$ 
```

**Scenario 4: Device detached and re-attached with different path. Only the latest volumeattachment with updated devicepath reported.**

<img width="980" alt="Screenshot 2023-12-13 at 7 28 13 PM" src="https://github.com/libopenstorage/cloudops/assets/4953411/0239712e-eea5-4133-b1b8-72bab8999a2f">


```
[opc@oke-cii3qdqu64q-nxlffs5mlra-sraq6gvhj3a-0 oracle]$ go test -v .
=== RUN   TestAll
Running all oracle teststime="2023-12-13T13:59:14Z" level=info msg="Trying to get device path for ocid1.volume.oc1.iad.abuwcljs3m3r5tudbxk5rdkeddni5bk47jrk66fn4jzdbin4lderucxfu4vq\n"
time="2023-12-13T13:59:14Z" level=info msg="disk: ocid1.volume.oc1.iad.abuwcljs3m3r5tudbxk5rdkeddni5bk47jrk66fn4jzdbin4lderucxfu4vq device path is: /dev/oracleoci/oraclevdc"
--- PASS: TestAll (0.13s)
PASS
ok      github.com/libopenstorage/cloudops/oracle       0.146s
```
