### PR TITLE
PWX-35575: Fix nil panic when unable to get GCE creds.

### DIFF
--- a/gce/gce.go
+++ b/gce/gce.go
@@ -1244,6 +1244,9 @@ func gceInfo(ctx context.Context, inst *instance) error {
 	}
 
 	credential, err := google.FindDefaultCredentials(ctx)
+	if err != nil {
+		return err
+	}
 	content := map[string]interface{}{}
 	json.Unmarshal(credential.JSON, &content)
 	if content["client_email"] != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid nil panic when FindDefaultCredentials returns an error.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35575

**Special notes for your reviewer**:
* Writing a UT for this is not feasible as func gceInfo() makes metadata.* calls which under the hood make REST API calls which will not work for UTs. These are not interface functions either so can't be mocked. The function will always fail before we reach the code which resulted in the panic.

