### PR TITLE
PTX-23265: change travis go version to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: go
 go:
-  - 1.18.x
+  - 1.20.x
 cache:
   directories:
     - $GOPATH/pkg/mod


### PR DESCRIPTION
Change go version in travis.yml to 1.20 from 1.18. The version 1.18 lint is failing in the go get -u process.


