### PR TITLE
PWX-36933 - update decision matrix for new disk types

### DIFF
--- a/azure/base_vmsclient.go
+++ b/azure/base_vmsclient.go
@@ -57,10 +57,14 @@ func (b *baseVMsClient) updateDataDisks(
 	instanceName string,
 	dataDisks []compute.DataDisk,
 ) error {
+	ultraSSDenabled := true
 	updatedVM := compute.VirtualMachineUpdate{
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			StorageProfile: &compute.StorageProfile{
 				DataDisks: &dataDisks,
+			},
+			AdditionalCapabilities: &compute.AdditionalCapabilities{
+				UltraSSDEnabled: &ultraSSDenabled,
 			},
 		},
 	}

--- a/azure/storagemanager/azure_test.go
+++ b/azure/storagemanager/azure_test.go
@@ -71,7 +71,7 @@ func storageDistribution(t *testing.T) {
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 256,
-						DriveType:        "UltraSSD_LRS",
+						DriveType:        "Premium_LRS",
 						InstancesPerZone: 2,
 						DriveCount:       1,
 						IOPS:             1100,
@@ -117,7 +117,7 @@ func storageDistribution(t *testing.T) {
 						IOPS:        5000,
 						MinCapacity: 9216,
 						MaxCapacity: 90000,
-						DriveType:   "PremiumV2_LRS",
+						DriveType:   "Premium_LRS",
 					},
 				},
 				InstanceType:     "foo",
@@ -129,7 +129,7 @@ func storageDistribution(t *testing.T) {
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 1024,
-						DriveType:        "PremiumV2_LRS",
+						DriveType:        "Premium_LRS",
 						InstancesPerZone: 3,
 						DriveCount:       1,
 						IOPS:             5000,
@@ -202,7 +202,6 @@ func storageDistribution(t *testing.T) {
 						IOPS:        7500,
 						MinCapacity: 4096,
 						MaxCapacity: 100000,
-						DriveType:   "UltraSSD_LRS",
 					},
 				},
 				InstanceType:     "foo",
@@ -213,7 +212,7 @@ func storageDistribution(t *testing.T) {
 				InstanceStorage: []*cloudops.StoragePoolSpec{
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 2048,
-						DriveType:        "UltraSSD_LRS",
+						DriveType:        "Premium_LRS",
 						InstancesPerZone: 1,
 						DriveCount:       1,
 						IOPS:             7500,
@@ -265,7 +264,6 @@ func storageDistribution(t *testing.T) {
 						IOPS:        5000,
 						MinCapacity: 9216,
 						MaxCapacity: 90000,
-						DriveType:   "PremiumV2_LRS",
 					},
 				},
 				InstanceType:     "foo",
@@ -283,7 +281,7 @@ func storageDistribution(t *testing.T) {
 					},
 					&cloudops.StoragePoolSpec{
 						DriveCapacityGiB: 1024,
-						DriveType:        "PremiumV2_LRS",
+						DriveType:        "Premium_LRS",
 						InstancesPerZone: 3,
 						DriveCount:       1,
 						IOPS:             5000,
@@ -383,7 +381,7 @@ func storageUpdate(t *testing.T) {
 						DriveCapacityGiB: 512,
 						DriveType:        "UltraSSD_LRS",
 						DriveCount:       3,
-						IOPS:             1100,
+						IOPS:             9600,
 					},
 				},
 			},

--- a/azure/storagemanager/testspecs/azure-storage-decision-matrix.yaml
+++ b/azure/storagemanager/testspecs/azure-storage-decision-matrix.yaml
@@ -219,223 +219,25 @@ rows:
           priority: 3
           thin_provisioning: false
           drive_type: "Standard_LRS"
-        - min_iops: 120
-          max_iops: 120
+        - min_iops: 3000
+          max_iops: 80000
           instance_type: "*"
           instance_max_drives: 8
           instance_min_drives: 1
           region: "*"
           min_size: 32
-          max_size: 64
+          max_size: 65536
           priority: 2
           thin_provisioning: false
           drive_type: "PremiumV2_LRS"
-        - min_iops: 240
-          max_iops: 240
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 64
-          max_size: 128
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 500
-          max_iops: 500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 128
-          max_size: 256
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 1100
-          max_iops: 1100
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 256
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 2300
-          max_iops: 2300
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 512
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 5000
-          max_iops: 5000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 1024
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 7500
-          max_iops: 7500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 2048
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 16000
-          max_iops: 16000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 8192
-          max_size: 16384
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 18000
-          max_iops: 18000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 16384
-          max_size: 32768
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 20000
-          max_iops: 20000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 32768
-          max_size: 32768
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 120
-          max_iops: 120
+        - min_iops: 9600
+          max_iops: 400000
           instance_type: "*"
           instance_max_drives: 8
           instance_min_drives: 1
           region: "*"
           min_size: 32
-          max_size: 64
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 240
-          max_iops: 240
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 64
-          max_size: 128
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 500
-          max_iops: 500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 128
-          max_size: 256
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 1100
-          max_iops: 1100
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 256
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 2300
-          max_iops: 2300
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 512
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 5000
-          max_iops: 5000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 1024
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 7500
-          max_iops: 7500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 2048
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 16000
-          max_iops: 16000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 8192
-          max_size: 16384
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 18000
-          max_iops: 18000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 16384
-          max_size: 32768
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 20000
-          max_iops: 20000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 32768
-          max_size: 32768
+          max_size: 65536
           priority: 2
           thin_provisioning: false
           drive_type: "UltraSSD_LRS"

--- a/specs/decisionmatrix/azure.yaml
+++ b/specs/decisionmatrix/azure.yaml
@@ -219,222 +219,24 @@ rows:
           priority: 3
           thin_provisioning: false
           drive_type: "Standard_LRS"
-        - min_iops: 120
-          max_iops: 120
+        - min_iops: 19000
+          max_iops: 80000
           instance_type: "*"
           instance_max_drives: 8
           instance_min_drives: 1
           region: "*"
           min_size: 32
-          max_size: 64
+          max_size: 65536
           priority: 2
           thin_provisioning: false
           drive_type: "PremiumV2_LRS"
-        - min_iops: 240
-          max_iops: 240
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 64
-          max_size: 128
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 500
-          max_iops: 500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 128
-          max_size: 256
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 1100
-          max_iops: 1100
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 256
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 2300
-          max_iops: 2300
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 512
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 5000
-          max_iops: 5000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 1024
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 7500
-          max_iops: 7500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 2048
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 16000
-          max_iops: 16000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 8192
-          max_size: 16384
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 18000
-          max_iops: 18000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 16384
-          max_size: 32768
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 20000
-          max_iops: 20000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 32768
-          max_size: 32768
-          priority: 2
-          thin_provisioning: false
-          drive_type: "PremiumV2_LRS"
-        - min_iops: 120
-          max_iops: 120
+        - min_iops: 9600
+          max_iops: 400000
           instance_type: "*"
           instance_max_drives: 8
           instance_min_drives: 1
           region: "*"
           min_size: 32
-          max_size: 64
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 240
-          max_iops: 240
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 64
-          max_size: 128
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 500
-          max_iops: 500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 128
-          max_size: 256
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 1100
-          max_iops: 1100
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 256
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 2300
-          max_iops: 2300
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 512
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 5000
-          max_iops: 5000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 1024
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 7500
-          max_iops: 7500
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 2048
-          max_size: 8192
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 16000
-          max_iops: 16000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 8192
-          max_size: 16384
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 18000
-          max_iops: 18000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 16384
-          max_size: 32768
-          priority: 2
-          thin_provisioning: false
-          drive_type: "UltraSSD_LRS"
-        - min_iops: 20000
-          max_iops: 20000
-          instance_type: "*"
-          instance_max_drives: 8
-          instance_min_drives: 1
-          region: "*"
-          min_size: 32768
           max_size: 32768
           priority: 2
           thin_provisioning: false

--- a/specs/decisionmatrix/azure.yaml
+++ b/specs/decisionmatrix/azure.yaml
@@ -219,7 +219,7 @@ rows:
           priority: 3
           thin_provisioning: false
           drive_type: "Standard_LRS"
-        - min_iops: 19000
+        - min_iops: 3000
           max_iops: 80000
           instance_type: "*"
           instance_max_drives: 8
@@ -237,7 +237,7 @@ rows:
           instance_min_drives: 1
           region: "*"
           min_size: 32
-          max_size: 32768
+          max_size: 65536
           priority: 2
           thin_provisioning: false
           drive_type: "UltraSSD_LRS"


### PR DESCRIPTION

**What this PR does / why we need it**:
Update decision matrix for azure disks - premiumv2 and ultradisk

**Which issue(s) this PR fixes** (optional)
PWX-36933

**Special notes for your reviewer**:
Teted -
PASS
coverage: 90.9% of statements
ok  	github.com/libopenstorage/cloudops/vsphere/storagemanager	0.010s	coverage: 90.9% of statements

