### PR TITLE
PWX-37022 Support resize-drive for ultradisk

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -613,21 +613,21 @@ func (a *azureOps) Expand(
 	// Azure resizes in chunks of GiB even if the disk properties variable is DiskSizeGB
 	newSizeInGiBInt32 := int32(newSizeInGiB)
 	disk.DiskProperties.DiskSizeGB = &newSizeInGiBInt32
-	logrus.Infof("Dolly Log Expand *disk %v", disk.Sku.Name)
-	logrus.Infof("Dolly Log Expand newSizeInGiBInt32 %v", newSizeInGiBInt32)
+
+	//The minimum guaranteed IOPS per disk are 1 IOPS/GiB,
+	//with an overall baseline minimum of 100 IOPS.
+	//For example, if you provisioned a 4-GiB ultra disk,
+	//the minimum IOPS for that disk is 100, instead of four.
+	//https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#ultra-disk-iops
 	if disk.Sku.Name == compute.UltraSSDLRS {
 		newIops := int64(newSizeInGiB)
-		logrus.Infof("Dolly Log Expand newIopsReadWriteInt64 %v", newIops)
 		if *disk.DiskProperties.DiskIOPSReadOnly < newIops {
 			disk.DiskProperties.DiskIOPSReadOnly = &newIops
-			logrus.Infof("Dolly Log Expand disk.DiskProperties.DiskIOPSReadWrite %v", *disk.DiskProperties.DiskIOPSReadWrite)
 		}
 		if *disk.DiskProperties.DiskIOPSReadWrite < newIops {
 			disk.DiskProperties.DiskIOPSReadWrite = &newIops
-			logrus.Infof("Dolly Log Expand disk.DiskProperties.DiskIOPSReadWrite %v", *disk.DiskProperties.DiskIOPSReadWrite)
 		}
 	}
-	logrus.Infof("Dolly Log Expand %v", *disk.DiskProperties.DiskIOPSReadWrite)
 	ctx := context.Background()
 	future, err := a.disksClient.CreateOrUpdate(
 		ctx,

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -613,7 +613,21 @@ func (a *azureOps) Expand(
 	// Azure resizes in chunks of GiB even if the disk properties variable is DiskSizeGB
 	newSizeInGiBInt32 := int32(newSizeInGiB)
 	disk.DiskProperties.DiskSizeGB = &newSizeInGiBInt32
-
+	logrus.Infof("Dolly Log Expand *disk %v", disk.Sku.Name)
+	logrus.Infof("Dolly Log Expand newSizeInGiBInt32 %v", newSizeInGiBInt32)
+	if disk.Sku.Name == compute.UltraSSDLRS {
+		newIops := int64(newSizeInGiB)
+		logrus.Infof("Dolly Log Expand newIopsReadWriteInt64 %v", newIops)
+		if *disk.DiskProperties.DiskIOPSReadOnly < newIops {
+			disk.DiskProperties.DiskIOPSReadOnly = &newIops
+			logrus.Infof("Dolly Log Expand disk.DiskProperties.DiskIOPSReadWrite %v", *disk.DiskProperties.DiskIOPSReadWrite)
+		}
+		if *disk.DiskProperties.DiskIOPSReadWrite < newIops {
+			disk.DiskProperties.DiskIOPSReadWrite = &newIops
+			logrus.Infof("Dolly Log Expand disk.DiskProperties.DiskIOPSReadWrite %v", *disk.DiskProperties.DiskIOPSReadWrite)
+		}
+	}
+	logrus.Infof("Dolly Log Expand %v", *disk.DiskProperties.DiskIOPSReadWrite)
 	ctx := context.Background()
 	future, err := a.disksClient.CreateOrUpdate(
 		ctx,

--- a/specs/decisionmatrix/azure.yaml
+++ b/specs/decisionmatrix/azure.yaml
@@ -230,7 +230,7 @@ rows:
           priority: 2
           thin_provisioning: false
           drive_type: "PremiumV2_LRS"
-        - min_iops: 9600
+        - min_iops: 100
           max_iops: 400000
           instance_type: "*"
           instance_max_drives: 8


### PR DESCRIPTION
**What this PR does / why we need it**:
We were unable to resize UltraDisk because for ultra disk the minimum IOPS change with every GiB.
```The minimum guaranteed IOPS per disk are 1 IOPS/GiB, with an overall baseline minimum of 100 IOPS. For example, if you provisioned a 4-GiB ultra disk, the minimum IOPS for that disk is 100, instead of four.```
https://learn.microsoft.com/en-us/azure/virtual-machines/disks-types#ultra-disk-iops

**Which issue(s) this PR fixes** (optional)
Closes https://purestorage.atlassian.net/browse/PWX-37022

**Special notes for your reviewer**:
In the current implementation, we did not update the minimum readonly IOPS andminimum ReadwriteIOPS. For ultra as the minimum changes with every GB - the resize was failing.

Automation - https://jenkins.pwx.dev.purestorage.com/job/Users/job/Dolly/job/dtalreja-Azure-ultraDisk/12/
