### PR TITLE
Get max drive size cloudops interface

### DIFF
--- a/aws/storagemanager/aws.go
+++ b/aws/storagemanager/aws.go
@@ -79,6 +79,12 @@ func (a *awsStorageManager) RecommendStoragePoolUpdate(
 	return resp, nil
 }
 
+func (a *awsStorageManager) GetMaxDriveSize(
+	request *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	resp, err := storagedistribution.GetMaxDriveSize(request, a.decisionMatrix)
+	return resp, err
+}
+
 func determineIOPSForPool(instStorage *cloudops.StoragePoolSpec, row *cloudops.StorageDecisionMatrixRow, currentIOPS uint64) uint64 {
 	if instStorage.DriveType == DriveTypeGp2 {
 		return instStorage.DriveCapacityGiB * Gp2IopsMultiplier

--- a/aws/storagemanager/aws_test.go
+++ b/aws/storagemanager/aws_test.go
@@ -30,6 +30,7 @@ func TestAWSStorageManager(t *testing.T) {
 	t.Run("setup", setup)
 	t.Run("storageDistribution", storageDistribution)
 	t.Run("storageUpdate", storageUpdate)
+	t.Run("maxDriveSize", maxDriveSize)
 }
 
 func setup(t *testing.T) {
@@ -770,6 +771,66 @@ func storageUpdate(t *testing.T) {
 			}
 		} else {
 			require.NotNil(t, err, "RecommendInstanceStorageUpdate should have returned an error")
+			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
+		}
+	}
+}
+
+func maxDriveSize(t *testing.T) {
+	testMatrix := []struct {
+		expectedErr error
+		request     *cloudops.MaxDriveSizeRequest
+		response    *cloudops.MaxDriveSizeResponse
+	}{
+		{
+			// Test1: empty drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrInvalidMaxDriveSizeRequest{Request: &cloudops.MaxDriveSizeRequest{DriveType: ""}, Reason: "empty drive type"},
+		},
+		{
+			// Test2: invalid drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "invalid_drive",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrMaxDriveSizeCandidateNotFound{Request: &cloudops.MaxDriveSizeRequest{DriveType: "invalid_drive"}, Reason: "no matching inputs found for input drive type"},
+		},
+
+		{
+			// Test3: gp2 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "gp2",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 16000,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test4: io1 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "io1",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 16000,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for j, test := range testMatrix {
+		fmt.Println("Executing test case: ", j+1)
+		response, err := storageManager.GetMaxDriveSize(test.request)
+		if test.expectedErr == nil {
+			require.Nil(t, err, "GetMaxDriveSize returned an error")
+			require.NotNil(t, response, "GetMaxDriveSize returned empty response")
+			require.Equal(t, test.response.MaxSize, response.MaxSize, "expected and actual max drive size not equal")
+		} else {
+			require.NotNil(t, err, "GetMaxDriveSize should have returned an error")
 			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
 		}
 	}

--- a/azure/storagemanager/azure.go
+++ b/azure/storagemanager/azure.go
@@ -67,6 +67,12 @@ func (a *azureStorageManager) RecommendStoragePoolUpdate(
 	return resp, nil
 }
 
+func (a *azureStorageManager) GetMaxDriveSize(
+	request *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	resp, err := storagedistribution.GetMaxDriveSize(request, a.decisionMatrix)
+	return resp, err
+}
+
 func determineIOPSForPool(row *cloudops.StorageDecisionMatrixRow) uint64 {
 	return row.MinIOPS
 }

--- a/cloud_storage_management.go
+++ b/cloud_storage_management.go
@@ -155,6 +155,17 @@ type StoragePoolUpdateResponse struct {
 	ResizeOperationType api.SdkStoragePool_ResizeOperationType
 }
 
+type MaxDriveSizeRequest struct {
+	// DriveType is the type of drive specified in terms of cloud provided names.
+	DriveType string `json:"drive_type" yaml:"drive_type"`
+}
+
+type MaxDriveSizeResponse struct {
+	// MaxSize is the maximum size of the drive that can be provisioned
+	// for input drive type.
+	MaxSize uint64 `json:"max_size" yaml:"max_size"`
+}
+
 // StorageManager interface provides a set of APIs to manage cloud storage drives
 // across multiple nodes in the cluster.
 type StorageManager interface {
@@ -163,6 +174,8 @@ type StorageManager interface {
 	// RecommendStoragePoolUpdate returns the recommended storage configuration on
 	// the instance based on the given request
 	RecommendStoragePoolUpdate(request *StoragePoolUpdateRequest) (*StoragePoolUpdateResponse, error)
+	// GetMaxDriveSize returns the maximum size a drive can expand to for given cloud drive type
+	GetMaxDriveSize(request *MaxDriveSizeRequest) (*MaxDriveSizeResponse, error)
 }
 
 var (
@@ -308,5 +321,12 @@ func (dm *StorageDecisionMatrix) SortByIOPS() *StorageDecisionMatrix {
 func (dm *StorageDecisionMatrix) SortByPriority() {
 	sort.SliceStable(dm.Rows, func(l, r int) bool {
 		return dm.Rows[l].Priority < dm.Rows[r].Priority
+	})
+}
+
+// SortByMaxSize sorts the rows of the decision matrix in descending order by MaxSize supported by that row.
+func (dm *StorageDecisionMatrix) SortByMaxSize() {
+	sort.SliceStable(dm.Rows, func(l, r int) bool {
+		return dm.Rows[l].MaxSize > dm.Rows[r].MaxSize
 	})
 }

--- a/csi/storagemanager/csi.go
+++ b/csi/storagemanager/csi.go
@@ -63,6 +63,12 @@ func (a *csiStorageManager) RecommendStoragePoolUpdate(
 	return resp, err
 }
 
+func (a *csiStorageManager) GetMaxDriveSize(
+	request *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	resp, err := storagedistribution.GetMaxDriveSize(request, a.decisionMatrix)
+	return resp, err
+}
+
 func init() {
 	cloudops.RegisterStorageManager(cloudops.CSI, newCSIStorageManager)
 }

--- a/errors.go
+++ b/errors.go
@@ -126,3 +126,31 @@ type ErrCloudProviderRequestFailure struct {
 func (e *ErrCloudProviderRequestFailure) Error() string {
 	return fmt.Sprintf("Request %s returns %s", e.Request, e.Message)
 }
+
+// ErrInvalidMaxDriveSizeRequest is returned when an unsupported or invalid request
+// is sent to get the max drive size
+type ErrInvalidMaxDriveSizeRequest struct {
+	// Request is the request that caused the invalid error
+	Request *MaxDriveSizeRequest
+	// Reason is the reason why the request was invalid
+	Reason string
+}
+
+func (e *ErrInvalidMaxDriveSizeRequest) Error() string {
+	return fmt.Sprintf("Invalid request to get the max drive size: %s Request: %v",
+		e.Reason, e.Request)
+}
+
+// ErrMaxDriveSizeCandidateNotFound is returned when an unsupported or invalid request
+// is sent to get the max drive size
+type ErrMaxDriveSizeCandidateNotFound struct {
+	// Request is the request that caused the error
+	Request *MaxDriveSizeRequest
+	// Reason is the reason why the request caused an error
+	Reason string
+}
+
+func (e *ErrMaxDriveSizeCandidateNotFound) Error() string {
+	return fmt.Sprintf("could not find a suitable max drive size candidate: %s Request: %v",
+		e.Reason, e.Request)
+}

--- a/gce/storagemanager/gce_test.go
+++ b/gce/storagemanager/gce_test.go
@@ -30,6 +30,7 @@ func TestGCEStorageManager(t *testing.T) {
 	t.Run("setup", setup)
 	t.Run("storageDistribution", storageDistribution)
 	t.Run("storageUpdate", storageUpdate)
+	t.Run("maxDriveSize", maxDriveSize)
 }
 
 func setup(t *testing.T) {
@@ -816,6 +817,77 @@ func storageUpdate(t *testing.T) {
 			}
 		} else {
 			require.NotNil(t, err, "RecommendInstanceStorageUpdate should have returned an error")
+			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
+		}
+	}
+}
+
+func maxDriveSize(t *testing.T) {
+	testMatrix := []struct {
+		expectedErr error
+		request     *cloudops.MaxDriveSizeRequest
+		response    *cloudops.MaxDriveSizeResponse
+	}{
+		{
+			// Test1: empty drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrInvalidMaxDriveSizeRequest{Request: &cloudops.MaxDriveSizeRequest{DriveType: ""}, Reason: "empty drive type"},
+		},
+		{
+			// Test2: invalid drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "invalid_drive",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrMaxDriveSizeCandidateNotFound{Request: &cloudops.MaxDriveSizeRequest{DriveType: "invalid_drive"}, Reason: "no matching inputs found for input drive type"},
+		},
+
+		{
+			// Test3: GCEDriveTypeStandard drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: genDriveType(GCEDriveTypeBalanced),
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 64000,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test4: GCEDriveTypeBalanced drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: genDriveType(GCEDriveTypeBalanced),
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 64000,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test5: GCEDriveTypeSSD drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: genDriveType(GCEDriveTypeSSD),
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 64000,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for j, test := range testMatrix {
+		fmt.Println("Executing test case: ", j+1)
+		response, err := storageManager.GetMaxDriveSize(test.request)
+		if test.expectedErr == nil {
+			require.Nil(t, err, "GetMaxDriveSize returned an error")
+			require.NotNil(t, response, "GetMaxDriveSize returned empty response")
+			require.Equal(t, test.response.MaxSize, response.MaxSize, "expected and actual max drive size not equal")
+		} else {
+			require.NotNil(t, err, "GetMaxDriveSize should have returned an error")
 			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
 		}
 	}

--- a/mock/cloud_storage_management.mock.go
+++ b/mock/cloud_storage_management.mock.go
@@ -5,36 +5,50 @@
 package mock
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	cloudops "github.com/libopenstorage/cloudops"
+	reflect "reflect"
 )
 
-// MockStorageManager is a mock of StorageManager interface.
+// MockStorageManager is a mock of StorageManager interface
 type MockStorageManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageManagerMockRecorder
 }
 
-// MockStorageManagerMockRecorder is the mock recorder for MockStorageManager.
+// MockStorageManagerMockRecorder is the mock recorder for MockStorageManager
 type MockStorageManagerMockRecorder struct {
 	mock *MockStorageManager
 }
 
-// NewMockStorageManager creates a new mock instance.
+// NewMockStorageManager creates a new mock instance
 func NewMockStorageManager(ctrl *gomock.Controller) *MockStorageManager {
 	mock := &MockStorageManager{ctrl: ctrl}
 	mock.recorder = &MockStorageManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockStorageManager) EXPECT() *MockStorageManagerMockRecorder {
 	return m.recorder
 }
 
-// GetStorageDistribution mocks base method.
+// GetMaxDriveSize mocks base method
+func (m *MockStorageManager) GetMaxDriveSize(arg0 *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxDriveSize", arg0)
+	ret0, _ := ret[0].(*cloudops.MaxDriveSizeResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMaxDriveSize indicates an expected call of GetMaxDriveSize
+func (mr *MockStorageManagerMockRecorder) GetMaxDriveSize(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxDriveSize", reflect.TypeOf((*MockStorageManager)(nil).GetMaxDriveSize), arg0)
+}
+
+// GetStorageDistribution mocks base method
 func (m *MockStorageManager) GetStorageDistribution(arg0 *cloudops.StorageDistributionRequest) (*cloudops.StorageDistributionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageDistribution", arg0)
@@ -43,13 +57,13 @@ func (m *MockStorageManager) GetStorageDistribution(arg0 *cloudops.StorageDistri
 	return ret0, ret1
 }
 
-// GetStorageDistribution indicates an expected call of GetStorageDistribution.
+// GetStorageDistribution indicates an expected call of GetStorageDistribution
 func (mr *MockStorageManagerMockRecorder) GetStorageDistribution(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageDistribution", reflect.TypeOf((*MockStorageManager)(nil).GetStorageDistribution), arg0)
 }
 
-// RecommendStoragePoolUpdate mocks base method.
+// RecommendStoragePoolUpdate mocks base method
 func (m *MockStorageManager) RecommendStoragePoolUpdate(arg0 *cloudops.StoragePoolUpdateRequest) (*cloudops.StoragePoolUpdateResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecommendStoragePoolUpdate", arg0)
@@ -58,7 +72,7 @@ func (m *MockStorageManager) RecommendStoragePoolUpdate(arg0 *cloudops.StoragePo
 	return ret0, ret1
 }
 
-// RecommendStoragePoolUpdate indicates an expected call of RecommendStoragePoolUpdate.
+// RecommendStoragePoolUpdate indicates an expected call of RecommendStoragePoolUpdate
 func (mr *MockStorageManagerMockRecorder) RecommendStoragePoolUpdate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecommendStoragePoolUpdate", reflect.TypeOf((*MockStorageManager)(nil).RecommendStoragePoolUpdate), arg0)

--- a/mock/cloudops.mock.go
+++ b/mock/cloudops.mock.go
@@ -5,37 +5,36 @@
 package mock
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	cloudops "github.com/libopenstorage/cloudops"
+	reflect "reflect"
+	time "time"
 )
 
-// MockOps is a mock of Ops interface.
+// MockOps is a mock of Ops interface
 type MockOps struct {
 	ctrl     *gomock.Controller
 	recorder *MockOpsMockRecorder
 }
 
-// MockOpsMockRecorder is the mock recorder for MockOps.
+// MockOpsMockRecorder is the mock recorder for MockOps
 type MockOpsMockRecorder struct {
 	mock *MockOps
 }
 
-// NewMockOps creates a new mock instance.
+// NewMockOps creates a new mock instance
 func NewMockOps(ctrl *gomock.Controller) *MockOps {
 	mock := &MockOps{ctrl: ctrl}
 	mock.recorder = &MockOpsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOps) EXPECT() *MockOpsMockRecorder {
 	return m.recorder
 }
 
-// ApplyTags mocks base method.
+// ApplyTags mocks base method
 func (m *MockOps) ApplyTags(arg0 string, arg1, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyTags", arg0, arg1, arg2)
@@ -43,13 +42,28 @@ func (m *MockOps) ApplyTags(arg0 string, arg1, arg2 map[string]string) error {
 	return ret0
 }
 
-// ApplyTags indicates an expected call of ApplyTags.
+// ApplyTags indicates an expected call of ApplyTags
 func (mr *MockOpsMockRecorder) ApplyTags(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTags", reflect.TypeOf((*MockOps)(nil).ApplyTags), arg0, arg1, arg2)
 }
 
-// Attach mocks base method.
+// AreVolumesReadyToExpand mocks base method
+func (m *MockOps) AreVolumesReadyToExpand(arg0 []*string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AreVolumesReadyToExpand", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AreVolumesReadyToExpand indicates an expected call of AreVolumesReadyToExpand
+func (mr *MockOpsMockRecorder) AreVolumesReadyToExpand(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreVolumesReadyToExpand", reflect.TypeOf((*MockOps)(nil).AreVolumesReadyToExpand), arg0)
+}
+
+// Attach mocks base method
 func (m *MockOps) Attach(arg0 string, arg1 map[string]string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Attach", arg0, arg1)
@@ -58,13 +72,13 @@ func (m *MockOps) Attach(arg0 string, arg1 map[string]string) (string, error) {
 	return ret0, ret1
 }
 
-// Attach indicates an expected call of Attach.
+// Attach indicates an expected call of Attach
 func (mr *MockOpsMockRecorder) Attach(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Attach", reflect.TypeOf((*MockOps)(nil).Attach), arg0, arg1)
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockOps) Create(arg0 interface{}, arg1, arg2 map[string]string) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2)
@@ -73,13 +87,13 @@ func (m *MockOps) Create(arg0 interface{}, arg1, arg2 map[string]string) (interf
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockOpsMockRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockOps)(nil).Create), arg0, arg1, arg2)
 }
 
-// Delete mocks base method.
+// Delete mocks base method
 func (m *MockOps) Delete(arg0 string, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
@@ -87,13 +101,13 @@ func (m *MockOps) Delete(arg0 string, arg1 map[string]string) error {
 	return ret0
 }
 
-// Delete indicates an expected call of Delete.
+// Delete indicates an expected call of Delete
 func (mr *MockOpsMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockOps)(nil).Delete), arg0, arg1)
 }
 
-// DeleteFrom mocks base method.
+// DeleteFrom mocks base method
 func (m *MockOps) DeleteFrom(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFrom", arg0, arg1)
@@ -101,13 +115,13 @@ func (m *MockOps) DeleteFrom(arg0, arg1 string) error {
 	return ret0
 }
 
-// DeleteFrom indicates an expected call of DeleteFrom.
+// DeleteFrom indicates an expected call of DeleteFrom
 func (mr *MockOpsMockRecorder) DeleteFrom(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFrom", reflect.TypeOf((*MockOps)(nil).DeleteFrom), arg0, arg1)
 }
 
-// DeleteInstance mocks base method.
+// DeleteInstance mocks base method
 func (m *MockOps) DeleteInstance(arg0, arg1 string, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstance", arg0, arg1, arg2)
@@ -115,13 +129,13 @@ func (m *MockOps) DeleteInstance(arg0, arg1 string, arg2 time.Duration) error {
 	return ret0
 }
 
-// DeleteInstance indicates an expected call of DeleteInstance.
+// DeleteInstance indicates an expected call of DeleteInstance
 func (mr *MockOpsMockRecorder) DeleteInstance(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstance", reflect.TypeOf((*MockOps)(nil).DeleteInstance), arg0, arg1, arg2)
 }
 
-// Describe mocks base method.
+// Describe mocks base method
 func (m *MockOps) Describe() (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Describe")
@@ -130,13 +144,13 @@ func (m *MockOps) Describe() (interface{}, error) {
 	return ret0, ret1
 }
 
-// Describe indicates an expected call of Describe.
+// Describe indicates an expected call of Describe
 func (mr *MockOpsMockRecorder) Describe() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Describe", reflect.TypeOf((*MockOps)(nil).Describe))
 }
 
-// Detach mocks base method.
+// Detach mocks base method
 func (m *MockOps) Detach(arg0 string, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Detach", arg0, arg1)
@@ -144,13 +158,13 @@ func (m *MockOps) Detach(arg0 string, arg1 map[string]string) error {
 	return ret0
 }
 
-// Detach indicates an expected call of Detach.
+// Detach indicates an expected call of Detach
 func (mr *MockOpsMockRecorder) Detach(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Detach", reflect.TypeOf((*MockOps)(nil).Detach), arg0, arg1)
 }
 
-// DetachFrom mocks base method.
+// DetachFrom mocks base method
 func (m *MockOps) DetachFrom(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachFrom", arg0, arg1)
@@ -158,13 +172,13 @@ func (m *MockOps) DetachFrom(arg0, arg1 string) error {
 	return ret0
 }
 
-// DetachFrom indicates an expected call of DetachFrom.
+// DetachFrom indicates an expected call of DetachFrom
 func (mr *MockOpsMockRecorder) DetachFrom(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachFrom", reflect.TypeOf((*MockOps)(nil).DetachFrom), arg0, arg1)
 }
 
-// DeviceMappings mocks base method.
+// DeviceMappings mocks base method
 func (m *MockOps) DeviceMappings() (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeviceMappings")
@@ -173,13 +187,13 @@ func (m *MockOps) DeviceMappings() (map[string]string, error) {
 	return ret0, ret1
 }
 
-// DeviceMappings indicates an expected call of DeviceMappings.
+// DeviceMappings indicates an expected call of DeviceMappings
 func (mr *MockOpsMockRecorder) DeviceMappings() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeviceMappings", reflect.TypeOf((*MockOps)(nil).DeviceMappings))
 }
 
-// DevicePath mocks base method.
+// DevicePath mocks base method
 func (m *MockOps) DevicePath(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DevicePath", arg0)
@@ -188,13 +202,13 @@ func (m *MockOps) DevicePath(arg0 string) (string, error) {
 	return ret0, ret1
 }
 
-// DevicePath indicates an expected call of DevicePath.
+// DevicePath indicates an expected call of DevicePath
 func (mr *MockOpsMockRecorder) DevicePath(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DevicePath", reflect.TypeOf((*MockOps)(nil).DevicePath), arg0)
 }
 
-// Enumerate mocks base method.
+// Enumerate mocks base method
 func (m *MockOps) Enumerate(arg0 []*string, arg1 map[string]string, arg2 string) (map[string][]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Enumerate", arg0, arg1, arg2)
@@ -203,13 +217,13 @@ func (m *MockOps) Enumerate(arg0 []*string, arg1 map[string]string, arg2 string)
 	return ret0, ret1
 }
 
-// Enumerate indicates an expected call of Enumerate.
+// Enumerate indicates an expected call of Enumerate
 func (mr *MockOpsMockRecorder) Enumerate(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enumerate", reflect.TypeOf((*MockOps)(nil).Enumerate), arg0, arg1, arg2)
 }
 
-// Expand mocks base method.
+// Expand mocks base method
 func (m *MockOps) Expand(arg0 string, arg1 uint64, arg2 map[string]string) (uint64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Expand", arg0, arg1, arg2)
@@ -218,13 +232,13 @@ func (m *MockOps) Expand(arg0 string, arg1 uint64, arg2 map[string]string) (uint
 	return ret0, ret1
 }
 
-// Expand indicates an expected call of Expand.
+// Expand indicates an expected call of Expand
 func (mr *MockOpsMockRecorder) Expand(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expand", reflect.TypeOf((*MockOps)(nil).Expand), arg0, arg1, arg2)
 }
 
-// FreeDevices mocks base method.
+// FreeDevices mocks base method
 func (m *MockOps) FreeDevices() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FreeDevices")
@@ -233,13 +247,13 @@ func (m *MockOps) FreeDevices() ([]string, error) {
 	return ret0, ret1
 }
 
-// FreeDevices indicates an expected call of FreeDevices.
+// FreeDevices indicates an expected call of FreeDevices
 func (mr *MockOpsMockRecorder) FreeDevices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FreeDevices", reflect.TypeOf((*MockOps)(nil).FreeDevices))
 }
 
-// GetClusterSizeForInstance mocks base method.
+// GetClusterSizeForInstance mocks base method
 func (m *MockOps) GetClusterSizeForInstance(arg0 string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterSizeForInstance", arg0)
@@ -248,13 +262,13 @@ func (m *MockOps) GetClusterSizeForInstance(arg0 string) (int64, error) {
 	return ret0, ret1
 }
 
-// GetClusterSizeForInstance indicates an expected call of GetClusterSizeForInstance.
+// GetClusterSizeForInstance indicates an expected call of GetClusterSizeForInstance
 func (mr *MockOpsMockRecorder) GetClusterSizeForInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterSizeForInstance", reflect.TypeOf((*MockOps)(nil).GetClusterSizeForInstance), arg0)
 }
 
-// GetDeviceID mocks base method.
+// GetDeviceID mocks base method
 func (m *MockOps) GetDeviceID(arg0 interface{}) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeviceID", arg0)
@@ -263,13 +277,13 @@ func (m *MockOps) GetDeviceID(arg0 interface{}) (string, error) {
 	return ret0, ret1
 }
 
-// GetDeviceID indicates an expected call of GetDeviceID.
+// GetDeviceID indicates an expected call of GetDeviceID
 func (mr *MockOpsMockRecorder) GetDeviceID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceID", reflect.TypeOf((*MockOps)(nil).GetDeviceID), arg0)
 }
 
-// GetInstance mocks base method.
+// GetInstance mocks base method
 func (m *MockOps) GetInstance(arg0 string) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstance", arg0)
@@ -278,13 +292,13 @@ func (m *MockOps) GetInstance(arg0 string) (interface{}, error) {
 	return ret0, ret1
 }
 
-// GetInstance indicates an expected call of GetInstance.
+// GetInstance indicates an expected call of GetInstance
 func (mr *MockOpsMockRecorder) GetInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstance", reflect.TypeOf((*MockOps)(nil).GetInstance), arg0)
 }
 
-// GetInstanceGroupSize mocks base method.
+// GetInstanceGroupSize mocks base method
 func (m *MockOps) GetInstanceGroupSize(arg0 string) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceGroupSize", arg0)
@@ -293,13 +307,13 @@ func (m *MockOps) GetInstanceGroupSize(arg0 string) (int64, error) {
 	return ret0, ret1
 }
 
-// GetInstanceGroupSize indicates an expected call of GetInstanceGroupSize.
+// GetInstanceGroupSize indicates an expected call of GetInstanceGroupSize
 func (mr *MockOpsMockRecorder) GetInstanceGroupSize(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceGroupSize", reflect.TypeOf((*MockOps)(nil).GetInstanceGroupSize), arg0)
 }
 
-// Inspect mocks base method.
+// Inspect mocks base method
 func (m *MockOps) Inspect(arg0 []*string, arg1 map[string]string) ([]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Inspect", arg0, arg1)
@@ -308,13 +322,13 @@ func (m *MockOps) Inspect(arg0 []*string, arg1 map[string]string) ([]interface{}
 	return ret0, ret1
 }
 
-// Inspect indicates an expected call of Inspect.
+// Inspect indicates an expected call of Inspect
 func (mr *MockOpsMockRecorder) Inspect(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Inspect", reflect.TypeOf((*MockOps)(nil).Inspect), arg0, arg1)
 }
 
-// InspectInstance mocks base method.
+// InspectInstance mocks base method
 func (m *MockOps) InspectInstance(arg0 string) (*cloudops.InstanceInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectInstance", arg0)
@@ -323,13 +337,13 @@ func (m *MockOps) InspectInstance(arg0 string) (*cloudops.InstanceInfo, error) {
 	return ret0, ret1
 }
 
-// InspectInstance indicates an expected call of InspectInstance.
+// InspectInstance indicates an expected call of InspectInstance
 func (mr *MockOpsMockRecorder) InspectInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectInstance", reflect.TypeOf((*MockOps)(nil).InspectInstance), arg0)
 }
 
-// InspectInstanceGroupForInstance mocks base method.
+// InspectInstanceGroupForInstance mocks base method
 func (m *MockOps) InspectInstanceGroupForInstance(arg0 string) (*cloudops.InstanceGroupInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InspectInstanceGroupForInstance", arg0)
@@ -338,13 +352,13 @@ func (m *MockOps) InspectInstanceGroupForInstance(arg0 string) (*cloudops.Instan
 	return ret0, ret1
 }
 
-// InspectInstanceGroupForInstance indicates an expected call of InspectInstanceGroupForInstance.
+// InspectInstanceGroupForInstance indicates an expected call of InspectInstanceGroupForInstance
 func (mr *MockOpsMockRecorder) InspectInstanceGroupForInstance(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectInstanceGroupForInstance", reflect.TypeOf((*MockOps)(nil).InspectInstanceGroupForInstance), arg0)
 }
 
-// InstanceID mocks base method.
+// InstanceID mocks base method
 func (m *MockOps) InstanceID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceID")
@@ -352,28 +366,13 @@ func (m *MockOps) InstanceID() string {
 	return ret0
 }
 
-// InstanceID indicates an expected call of InstanceID.
+// InstanceID indicates an expected call of InstanceID
 func (mr *MockOpsMockRecorder) InstanceID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockOps)(nil).InstanceID))
 }
 
-// IsVolumesReadyToExpand mocks base method.
-func (m *MockOps) AreVolumesReadyToExpand(arg0 []*string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsVolumesReadyToExpand", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsVolumesReadyToExpand indicates an expected call of IsVolumesReadyToExpand.
-func (mr *MockOpsMockRecorder) IsVolumesReadyToExpand(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVolumesReadyToExpand", reflect.TypeOf((*MockOps)(nil).AreVolumesReadyToExpand), arg0)
-}
-
-// Name mocks base method.
+// Name mocks base method
 func (m *MockOps) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -381,13 +380,13 @@ func (m *MockOps) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name.
+// Name indicates an expected call of Name
 func (mr *MockOpsMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockOps)(nil).Name))
 }
 
-// RemoveTags mocks base method.
+// RemoveTags mocks base method
 func (m *MockOps) RemoveTags(arg0 string, arg1, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTags", arg0, arg1, arg2)
@@ -395,13 +394,13 @@ func (m *MockOps) RemoveTags(arg0 string, arg1, arg2 map[string]string) error {
 	return ret0
 }
 
-// RemoveTags indicates an expected call of RemoveTags.
+// RemoveTags indicates an expected call of RemoveTags
 func (mr *MockOpsMockRecorder) RemoveTags(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTags", reflect.TypeOf((*MockOps)(nil).RemoveTags), arg0, arg1, arg2)
 }
 
-// SetClusterVersion mocks base method.
+// SetClusterVersion mocks base method
 func (m *MockOps) SetClusterVersion(arg0 string, arg1 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetClusterVersion", arg0, arg1)
@@ -409,13 +408,13 @@ func (m *MockOps) SetClusterVersion(arg0 string, arg1 time.Duration) error {
 	return ret0
 }
 
-// SetClusterVersion indicates an expected call of SetClusterVersion.
+// SetClusterVersion indicates an expected call of SetClusterVersion
 func (mr *MockOpsMockRecorder) SetClusterVersion(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterVersion", reflect.TypeOf((*MockOps)(nil).SetClusterVersion), arg0, arg1)
 }
 
-// SetInstanceGroupSize mocks base method.
+// SetInstanceGroupSize mocks base method
 func (m *MockOps) SetInstanceGroupSize(arg0 string, arg1 int64, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceGroupSize", arg0, arg1, arg2)
@@ -423,13 +422,13 @@ func (m *MockOps) SetInstanceGroupSize(arg0 string, arg1 int64, arg2 time.Durati
 	return ret0
 }
 
-// SetInstanceGroupSize indicates an expected call of SetInstanceGroupSize.
+// SetInstanceGroupSize indicates an expected call of SetInstanceGroupSize
 func (mr *MockOpsMockRecorder) SetInstanceGroupSize(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceGroupSize", reflect.TypeOf((*MockOps)(nil).SetInstanceGroupSize), arg0, arg1, arg2)
 }
 
-// SetInstanceGroupVersion mocks base method.
+// SetInstanceGroupVersion mocks base method
 func (m *MockOps) SetInstanceGroupVersion(arg0, arg1 string, arg2 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstanceGroupVersion", arg0, arg1, arg2)
@@ -437,13 +436,13 @@ func (m *MockOps) SetInstanceGroupVersion(arg0, arg1 string, arg2 time.Duration)
 	return ret0
 }
 
-// SetInstanceGroupVersion indicates an expected call of SetInstanceGroupVersion.
+// SetInstanceGroupVersion indicates an expected call of SetInstanceGroupVersion
 func (mr *MockOpsMockRecorder) SetInstanceGroupVersion(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceGroupVersion", reflect.TypeOf((*MockOps)(nil).SetInstanceGroupVersion), arg0, arg1, arg2)
 }
 
-// Snapshot mocks base method.
+// Snapshot mocks base method
 func (m *MockOps) Snapshot(arg0 string, arg1 bool, arg2 map[string]string) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Snapshot", arg0, arg1, arg2)
@@ -452,13 +451,13 @@ func (m *MockOps) Snapshot(arg0 string, arg1 bool, arg2 map[string]string) (inte
 	return ret0, ret1
 }
 
-// Snapshot indicates an expected call of Snapshot.
+// Snapshot indicates an expected call of Snapshot
 func (mr *MockOpsMockRecorder) Snapshot(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockOps)(nil).Snapshot), arg0, arg1, arg2)
 }
 
-// SnapshotDelete mocks base method.
+// SnapshotDelete mocks base method
 func (m *MockOps) SnapshotDelete(arg0 string, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SnapshotDelete", arg0, arg1)
@@ -466,13 +465,13 @@ func (m *MockOps) SnapshotDelete(arg0 string, arg1 map[string]string) error {
 	return ret0
 }
 
-// SnapshotDelete indicates an expected call of SnapshotDelete.
+// SnapshotDelete indicates an expected call of SnapshotDelete
 func (mr *MockOpsMockRecorder) SnapshotDelete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnapshotDelete", reflect.TypeOf((*MockOps)(nil).SnapshotDelete), arg0, arg1)
 }
 
-// Tags mocks base method.
+// Tags mocks base method
 func (m *MockOps) Tags(arg0 string) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tags", arg0)
@@ -481,7 +480,7 @@ func (m *MockOps) Tags(arg0 string) (map[string]string, error) {
 	return ret0, ret1
 }
 
-// Tags indicates an expected call of Tags.
+// Tags indicates an expected call of Tags
 func (mr *MockOpsMockRecorder) Tags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tags", reflect.TypeOf((*MockOps)(nil).Tags), arg0)

--- a/oracle/storagemanager/oracle.go
+++ b/oracle/storagemanager/oracle.go
@@ -70,6 +70,12 @@ func (o *oracleStorageManager) RecommendStoragePoolUpdate(request *cloudops.Stor
 	return resp, nil
 }
 
+func (o *oracleStorageManager) GetMaxDriveSize(
+	request *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	resp, err := storagedistribution.GetMaxDriveSize(request, o.decisionMatrix)
+	return resp, err
+}
+
 func determineIOPSForPool(instStorage *cloudops.StoragePoolSpec, row *cloudops.StorageDecisionMatrixRow) uint64 {
 	var iopsPerGB, maxIopsPerVol int64
 	switch row.DriveType {

--- a/oracle/storagemanager/oracle_test.go
+++ b/oracle/storagemanager/oracle_test.go
@@ -30,6 +30,7 @@ func TestOracleStorageManager(t *testing.T) {
 	t.Run("setup", setup)
 	t.Run("storageDistribution", storageDistribution)
 	t.Run("storageUpdate", storageUpdate)
+	t.Run("maxDriveSize", maxDriveSize)
 }
 
 func setup(t *testing.T) {
@@ -560,6 +561,187 @@ func storageUpdate(t *testing.T) {
 			}
 		} else {
 			require.NotNil(t, err, "RecommendInstanceStorageUpdate should have returned an error")
+			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
+		}
+	}
+}
+
+func maxDriveSize(t *testing.T) {
+	testMatrix := []struct {
+		expectedErr error
+		request     *cloudops.MaxDriveSizeRequest
+		response    *cloudops.MaxDriveSizeResponse
+	}{
+		{
+			// Test1: empty drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrInvalidMaxDriveSizeRequest{Request: &cloudops.MaxDriveSizeRequest{DriveType: ""}, Reason: "empty drive type"},
+		},
+		{
+			// Test2: invalid drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "invalid_drive",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrMaxDriveSizeCandidateNotFound{Request: &cloudops.MaxDriveSizeRequest{DriveType: "invalid_drive"}, Reason: "no matching inputs found for input drive type"},
+		},
+
+		{
+			// Test3: pv-0 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-0",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test4: pv-10 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-10",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test5: pv-20 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-20",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test6: pv-30 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-30",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test7: pv-40 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-40",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test8: pv-50 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-50",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test9: pv-60 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-60",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test10: pv-70 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-70",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test11: pv-80 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-80",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test12: pv-90 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-90",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test13: pv-100 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-100",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test14: pv-110 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-110",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test15: pv-120 drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "pv-120",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 32768,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for j, test := range testMatrix {
+		fmt.Println("Executing test case: ", j+1)
+		response, err := storageManager.GetMaxDriveSize(test.request)
+		if test.expectedErr == nil {
+			require.Nil(t, err, "GetMaxDriveSize returned an error")
+			require.NotNil(t, response, "GetMaxDriveSize returned empty response")
+			require.Equal(t, test.response.MaxSize, response.MaxSize, "expected and actual max drive size not equal")
+		} else {
+			require.NotNil(t, err, "GetMaxDriveSize should have returned an error")
 			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
 		}
 	}

--- a/unsupported/unsupported.go
+++ b/unsupported/unsupported.go
@@ -217,3 +217,10 @@ func (u *unsupportedStorageManager) RecommendStoragePoolUpdate(
 		Operation: "RecommendStoragePoolUpdate",
 	}
 }
+
+func (u *unsupportedStorageManager) GetMaxDriveSize(
+	request *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	return nil, &cloudops.ErrNotSupported{
+		Operation: "GetMaxDriveSize",
+	}
+}

--- a/vsphere/storagemanager/vsphere.go
+++ b/vsphere/storagemanager/vsphere.go
@@ -55,6 +55,13 @@ func (a *vsphereStorageManager) RecommendStoragePoolUpdate(
 	resp, _, err := storagedistribution.GetStorageUpdateConfig(request, a.decisionMatrix)
 	return resp, err
 }
+
+func (a *vsphereStorageManager) GetMaxDriveSize(
+	request *cloudops.MaxDriveSizeRequest) (*cloudops.MaxDriveSizeResponse, error) {
+	resp, err := storagedistribution.GetMaxDriveSize(request, a.decisionMatrix)
+	return resp, err
+}
+
 func init() {
 	cloudops.RegisterStorageManager(cloudops.Vsphere, newVsphereStorageManager)
 }

--- a/vsphere/storagemanager/vsphere_test.go
+++ b/vsphere/storagemanager/vsphere_test.go
@@ -1,3 +1,4 @@
+//go:build unittest
 // +build unittest
 
 package storagemanager
@@ -32,6 +33,7 @@ func TestVsphereStorageManager(t *testing.T) {
 	t.Run("setup", setup)
 	t.Run("storageDistribution", storageDistribution)
 	t.Run("storageUpdate", storageUpdate)
+	t.Run("maxDriveSize", maxDriveSize)
 }
 
 func setup(t *testing.T) {
@@ -413,6 +415,77 @@ func storageUpdate(t *testing.T) {
 		} else {
 			require.NotNil(t, err, "RecommendInstanceStorageUpdate should have returned an error")
 			require.Equal(t, test.expectedErr, err, "received unexpected type of error")
+		}
+	}
+}
+
+func maxDriveSize(t *testing.T) {
+	testMatrix := []struct {
+		expectedErr error
+		request     *cloudops.MaxDriveSizeRequest
+		response    *cloudops.MaxDriveSizeResponse
+	}{
+		{
+			// Test1: empty drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrInvalidMaxDriveSizeRequest{Request: &cloudops.MaxDriveSizeRequest{DriveType: ""}, Reason: "empty drive type"},
+		},
+		{
+			// Test2: invalid drive type
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "invalid_drive",
+			},
+			response:    nil,
+			expectedErr: &cloudops.ErrMaxDriveSizeCandidateNotFound{Request: &cloudops.MaxDriveSizeRequest{DriveType: "invalid_drive"}, Reason: "no matching inputs found for input drive type"},
+		},
+
+		{
+			// Test3: thin drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "thin",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 8192,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test4: zeroedthick drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "zeroedthick",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 8192,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			// Test5: eagerzeroedthick drive
+			request: &cloudops.MaxDriveSizeRequest{
+				DriveType: "eagerzeroedthick",
+			},
+			response: &cloudops.MaxDriveSizeResponse{
+				MaxSize: 8192,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for j, test := range testMatrix {
+		fmt.Println("Executing test case: ", j+1)
+		response, err := storageManager.GetMaxDriveSize(test.request)
+		if test.expectedErr == nil {
+			require.Nil(t, err, "GetMaxDriveSize returned an error")
+			require.NotNil(t, response, "GetMaxDriveSize returned empty response")
+			require.Equal(t, test.response.MaxSize, response.MaxSize, "expected and actual max drive size not equal")
+		} else {
+			require.NotNil(t, err, "GetMaxDriveSize should have returned an error")
+			require.Equal(t, test.expectedErr.Error(), err.Error(), "received unexpected type of error")
 		}
 	}
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->
```
root@diags:~/git/go/src/github.com/libopenstorage/cloudops# make
go build -tags ""  ./...
go vet ./...
```

```
root@diags:~/git/go/src/github.com/libopenstorage/cloudops# grep -snr maxDriveSize ~/test_out
631:=== RUN   TestAWSStorageManager/maxDriveSize
644:    --- PASS: TestAWSStorageManager/maxDriveSize (0.00s)
840:=== RUN   TestAzureStorageManager/maxDriveSize
859:    --- PASS: TestAzureStorageManager/maxDriveSize (0.00s)
1179:=== RUN   TestGCEStorageManager/maxDriveSize
1194:    --- PASS: TestGCEStorageManager/maxDriveSize (0.00s)
1395:=== RUN   TestOracleStorageManager/maxDriveSize
1430:    --- PASS: TestOracleStorageManager/maxDriveSize (0.01s)
1547:=== RUN   TestVsphereStorageManager/maxDriveSize
1562:    --- PASS: TestVsphereStorageManager/maxDriveSize (0.00s)
```

**What this PR does / why we need it**:
Add new interface to get max drive size for all clouds. For Pure, implementation is in porx and will be through different PR. For IBM, implementation is in csi.go

**Which issue(s) this PR fixes** (optional)
Closes PWX-37215
Closes PWX-37118

**Special notes for your reviewer**:
For Pure, implementation is in porx and will be added through different PR. For IBM, implementation is in csi.go
