### PR TITLE
Adding support for GKE upgrade strategy

### DIFF
--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -158,6 +158,25 @@ func (e *exponentialBackoff) SetInstanceGroupVersion(instanceGroupID string,
 
 }
 
+func (e *exponentialBackoff) SetInstanceUpgradeStrategy(instanceGroupID string,
+	upgradeStrategy string,
+	timeout time.Duration,
+	surgeSetting string) error {
+	var (
+		origErr error
+	)
+	conditionFn := func() (bool, error) {
+		origErr = e.cloudOps.SetInstanceUpgradeStrategy(instanceGroupID, upgradeStrategy, timeout, surgeSetting)
+		return e.handleError(origErr, fmt.Sprintf("Failed to set instance group version"))
+	}
+	expErr := wait.ExponentialBackoff(e.backoff, conditionFn)
+	if expErr == wait.ErrWaitTimeout {
+		return cloudops.NewStorageError(cloudops.ErrExponentialTimeout, origErr.Error(), "")
+	}
+	return origErr
+
+}
+
 func (e *exponentialBackoff) GetInstanceGroupSize(instanceGroupID string) (int64, error) {
 	var (
 		count   int64

--- a/cloudops.go
+++ b/cloudops.go
@@ -118,6 +118,11 @@ type Compute interface {
 	SetInstanceGroupVersion(instanceGroupID string,
 		version string,
 		timeout time.Duration) error
+	// SetInstanceUpgradeStrategy sets desired Upgrade strategy & respective parameters for the node group
+	SetInstanceUpgradeStrategy(instanceGroupID string,
+		upgradeStrategy string,
+		timeout time.Duration,
+		surgeSetting string) error
 }
 
 // Storage interface to manage storage operations.

--- a/gce/gce.go
+++ b/gce/gce.go
@@ -839,6 +839,76 @@ func (s *gceOps) SetInstanceGroupVersion(instanceGroupID string,
 	return s.WaitForOperationCompletion(operation, zonalCluster, timeout)
 }
 
+// SetInstanceUpgradeStrategy sets desired Upgrade strategy & respective parameters for the node group
+func (s *gceOps) SetInstanceUpgradeStrategy(instanceGroupID string,
+	upgradeStrategy string,
+	timeout time.Duration,
+	surgeSetting string) error {
+
+	// TODO: Add Blue_Green upgradeStrategy when supported
+
+	if upgradeStrategy == "surge" {
+		if surgeSetting == "" {
+			surgeSetting = "default"
+		}
+	}
+
+	MaxSurge := 0
+	MaxUnavailable := 0
+
+	switch surgeSetting {
+	case "default": // Balanced (Default), slower but least disruptive
+		MaxSurge = 1
+		MaxUnavailable = 0
+	case "fast-no-surge": // Fast, no surge resources, most disruptive
+		MaxSurge = 0
+		MaxUnavailable = 20
+	case "fast-surge": // Fast, most surge resources and less disruptive
+		MaxSurge = 20
+		MaxUnavailable = 0
+	case "slow": // Slowest, disruptive, no surge resources
+		MaxSurge = 0
+		MaxUnavailable = 1
+	default:
+		return fmt.Errorf("invalid surge setting: %s", surgeSetting)
+	}
+
+	nodePoolPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s",
+		s.inst.project, s.inst.clusterLocation, s.inst.clusterName, instanceGroupID)
+
+	updateNodePoolRequest := &container.UpdateNodePoolRequest{
+		Name: nodePoolPath,
+		UpgradeSettings: &container.UpgradeSettings{
+			MaxSurge:       int64(MaxSurge),
+			MaxUnavailable: int64(MaxUnavailable),
+		},
+	}
+
+	zonalCluster, err := isZonalCluster(s.inst.clusterLocation)
+	if err != nil {
+		return err
+	}
+
+	var operation *container.Operation
+	if zonalCluster {
+		operation, err = s.containerService.Projects.Zones.Clusters.NodePools.Update(s.inst.project,
+			s.inst.clusterLocation,
+			s.inst.clusterName,
+			instanceGroupID,
+			updateNodePoolRequest).Do()
+	} else {
+		operation, err = s.containerService.Projects.Locations.Clusters.NodePools.Update(
+			nodePoolPath,
+			updateNodePoolRequest).Do()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return s.WaitForOperationCompletion(operation, zonalCluster, timeout)
+}
+
 // SetInstanceGroupSize sets node count for a instance group.
 // Count here is per availability zone
 func (s *gceOps) SetInstanceGroupSize(instanceGroupID string,

--- a/unsupported/unsupported.go
+++ b/unsupported/unsupported.go
@@ -75,6 +75,15 @@ func (u *unsupportedCompute) SetInstanceGroupVersion(instanceGroupID string,
 	}
 }
 
+func (u *unsupportedCompute) SetInstanceUpgradeStrategy(instanceGroupID string,
+	upgradeStrategy string,
+	timeout time.Duration,
+	surgeSetting string) error {
+	return &cloudops.ErrNotSupported{
+		Operation: "SetInstanceUpgradeStrategy",
+	}
+}
+
 type unsupportedStorage struct {
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support for maxSurge and maxUnavailable values for surge upgrade strategy in GKE

Reference:
https://cloud.google.com/kubernetes-engine/docs/concepts/node-pool-upgrade-strategies#surge

**Which issue(s) this PR fixes** (optional)
Closes # PTX-24373

**Special notes for your reviewer**: N/A

