### PR TITLE
PWX-38340: fix race issues when updating k8s configmaps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/oracle/oci-go-sdk/v65 v65.13.1
 	github.com/pborman/uuid v1.2.0
 	github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
 	github.com/prometheus/client_golang v1.11.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.1
@@ -103,7 +103,7 @@ require (
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
 	github.com/prometheus/prometheus v2.9.2+incompatible => github.com/prometheus/prometheus v1.8.2-0.20190424153033-d3245f150225
 	github.com/vmware/govmomi => github.com/libopenstorage/govmomi v0.22.3-0.20200619175019-4b44cc8cf4d1
 	k8s.io/api => k8s.io/api v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -1140,8 +1140,8 @@ github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd h1:L/1So9aaNBBOKXUPL
 github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd/go.mod h1:srh8qY1VIUFoaJN5TWQ6yWkICy7OoyNZuAqT4JMgAgI=
 github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef/go.mod h1:puy7YVXeb6glot1vVCIePIiRLSwB//+rFtN2ZjvXeEw=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d h1:rvKuH7ySLx87qz2ydGBYtYjaTSUmwpGQhk+bGgOVo1k=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d/go.mod h1:5xy8TTt9m/8UGG8Hw5NHxwc/mctjCsmj7mpcR7jIFjI=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c h1:S8ZTtGBvLCjmdjz8pa9I7iz5BD0wdAS/BTbDpiN1QTc=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c/go.mod h1:5xy8TTt9m/8UGG8Hw5NHxwc/mctjCsmj7mpcR7jIFjI=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145/go.mod h1:CkLAs/ojTzSu3SPyeDxc3qhsbRU78H5Xz1qJlj1Ap1U=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/store/store.go
+++ b/store/store.go
@@ -2,8 +2,9 @@ package store
 
 import (
 	"fmt"
-	"github.com/portworx/kvdb"
 	"time"
+
+	"github.com/portworx/kvdb"
 )
 
 // PX specific scheduler constants
@@ -15,9 +16,9 @@ const (
 // Params is the parameters to use for the Store object
 type Params struct {
 	// Kv is the bootstrap kvdb instance
-	Kv            kvdb.Kvdb
+	Kv kvdb.Kvdb
 	// InternalKvdb indicates if PX is using internal kvdb or not
-	InternalKvdb  bool
+	InternalKvdb bool
 	// SchedulerType indicates the platform pods are running on. e.g Kubernetes
 	SchedulerType string
 }
@@ -27,10 +28,10 @@ type Lock struct {
 	// Key is the name on which the lock is acquired.
 	// This is used by the callers for logging purpose. Hence public
 	Key string
-	// Name of the owner who acquired the lock
-	owner string
+	// Name of the Owner who acquired the lock
+	Owner string
 	// true if this lock was acquired using LockWithKey() interface
-	lockedWithKey bool
+	LockedWithKey bool
 	// lock structure as returned from the KVDB interface
 	internalLock interface{}
 }
@@ -71,13 +72,13 @@ type Store interface {
 	LockWithKey(owner, key string) (*Lock, error)
 	// IsKeyLocked checks if the specified key is currently locked
 	IsKeyLocked(key string) (bool, string, error)
-	// CreateKey creates the given key with the value
-	CreateKey(key string, value []byte) error
-	// PutKey updates the given key with the value
-	PutKey(key string, value []byte) error
+	// CreateKey creates the given key with the value. lockAs argument is used as an owner to lock the key.
+	CreateKey(lockAs, key string, value []byte) error
+	// PutKey updates the given key with the value. lockAs argument is used as an owner to lock the key.
+	PutKey(lockAs, key string, value []byte) error
 	// GetKey returns the value for the given key
 	GetKey(key string) ([]byte, error)
-	// DeleteKey deletes the given key
+	// DeleteKey deletes the given key. Sanitized version of the key is used internally for locking.
 	DeleteKey(key string) error
 	// EnumerateWithKeyPrefix enumerates all keys in the store that begin with the given key
 	EnumerateWithKeyPrefix(key string) ([]string, error)

--- a/store/store_kv.go
+++ b/store/store_kv.go
@@ -107,7 +107,7 @@ func (kv *kvStore) LockWithKey(owner, key string) (*Lock, error) {
 		return nil, err
 	}
 
-	kvPair.lockedWithKey = true
+	kvPair.LockedWithKey = true
 	return kvPair, err
 }
 
@@ -124,13 +124,13 @@ func (kv *kvStore) IsKeyLocked(key string) (bool, string, error) {
 	return kv.k.IsKeyLocked(fullPath)
 }
 
-func (kv *kvStore) CreateKey(key string, value []byte) error {
+func (kv *kvStore) CreateKey(_, key string, value []byte) error {
 	key = kv.getFullKey(key)
 	_, err := kv.k.Create(key, string(value), 0)
 	return err
 }
 
-func (kv *kvStore) PutKey(key string, value []byte) error {
+func (kv *kvStore) PutKey(_, key string, value []byte) error {
 	key = kv.getFullKey(key)
 	_, err := kv.k.Put(key, string(value), 0)
 	return err

--- a/vendor/github.com/portworx/sched-ops/k8s/core/configmap/types.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/configmap/types.go
@@ -41,6 +41,10 @@ const (
 	// objects.
 	pxLockKey = "px-lock"
 
+	// pxGenerationKey stores the generation of the configmap data. The value is incremented every time
+	// the configmap data is updated via PatchKeyLocked or DeleteKeyLocked. This is used for diagnostics purposes only.
+	pxGenerationKey = "px-generation"
+
 	lockSleepDuration     = 1 * time.Second
 	configMapUserLabelKey = "user"
 	maxConflictRetries    = 3
@@ -49,26 +53,33 @@ const (
 var (
 	// ErrConfigMapLocked is returned when the ConfigMap is locked
 	ErrConfigMapLocked = errors.New("ConfigMap is locked")
-	fatalCb            FatalCb
-	configMapNameRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
+	// ErrConfigMapLockLost is returned when the ConfigMap lock expired and was taken away
+	ErrConfigMapLockLost = errors.New("ConfigMap lock was lost")
+	fatalCb              FatalCb
+	configMapNameRegex   = regexp.MustCompile("[^a-zA-Z0-9]+")
 )
 
 // FatalCb is a callback function which will be executed if the Lock
 // routine encounters a panic situation
 type FatalCb func(format string, args ...interface{})
 
+// CheckLockCb is a callback function to check if the lock is still valid.
+type CheckLockCb func(data map[string]string) bool
+
 type configMap struct {
-	name                string
-	kLockV1             k8sLock
-	kLocksV2Mutex       sync.Mutex
-	kLocksV2            map[string]*k8sLock
-	lockTimeout         time.Duration
-	lockAttempts        uint
-	lockRefreshDuration time.Duration
-	lockK8sLockTTL      time.Duration
+	name                   string
+	kLockV1                k8sLock
+	kLocksV2Mutex          sync.Mutex
+	kLocksV2               map[string]*k8sLock
+	lockHoldTimeoutV1      time.Duration
+	defaultLockHoldTimeout time.Duration
+	lockAttempts           uint
+	lockRefreshDuration    time.Duration
+	lockK8sLockTTL         time.Duration
 }
 
 type k8sLock struct {
+	wg       sync.WaitGroup
 	done     chan struct{}
 	unlocked bool
 	id       string
@@ -77,13 +88,24 @@ type k8sLock struct {
 
 // ConfigMap is an interface that provides a set of APIs over a single
 // k8s configmap object. The data in the configMap is managed as a map of string
-// to string
+// to string.
+//
+// Rules:
+//  1. Locks are non-reentrant.
+//  2. For v1 locks, use Lock()/LockWithParams() and Unlock(). For v2 locks, use LockWithKey() and UnlockWithKey().
+//  3. Use the same locking mechanism (v1 or v2) for a given key consistently. It is dangerous to change
+//     the locking mechanism for a key (e.g. during upgrade).
+//  4. Specify the correct locking mechanism and lock owner when using PatchKeyLocked() and DeleteKeyLocked().
+//  5. Do not patch/delete any of the internal keys used for the locks and expirations.
 type ConfigMap interface {
 	// Lock locks a configMap where id is the identification of
-	// the holder of the lock.
+	// the holder of the lock. Lock is non-reentrant.
 	Lock(id string) error
+	// LockWithParams similar to Lock but with custom params.
+	// If lockAttempts is 0, the value passed to configmap.New() is used.
+	LockWithParams(id string, holdTimeout time.Duration, lockAttempts uint) error
 	// LockWithKey locks a configMap where owner is the identification
-	// of the holder of the lock and key is the specific lock to take.
+	// of the holder of the lock and key is the specific lock to take.  Lock is non-reentrant.
 	LockWithKey(owner, key string) error
 	// Unlock unlocks the configMap.
 	Unlock() error
@@ -92,11 +114,14 @@ type ConfigMap interface {
 	// IsKeyLocked returns if the given key is locked, and if so, by which owner.
 	IsKeyLocked(key string) (bool, string, error)
 
-	// Patch updates only the keys provided in the input map.
-	// It does not replace the complete map
-	Patch(data map[string]string) error
-	// Update overwrites the data of the configmap
-	Update(data map[string]string) error
+	// PatchKeyLocked updates the specified key in the configMap. It verifies that
+	// the lock is still held by the specified owner. Lock needs to be held by the lockOwner
+	// throughout the patch operation for this function to succeed.
+	PatchKeyLocked(isV1Lock bool, lockOwner, key, val string) error
+
+	// DeleteKeyLocked deletes the specified key in the configMap.
+	DeleteKeyLocked(isV1Lock bool, lockOwner, key string) error
+
 	// Get returns the contents of the configMap
 	Get() (map[string]string, error)
 	// Delete deletes the configMap

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,7 +242,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd
 ## explicit; go 1.17
 github.com/portworx/kvdb
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d => github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c => github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
 ## explicit; go 1.12
 github.com/portworx/sched-ops/k8s/common
 github.com/portworx/sched-ops/k8s/core
@@ -736,7 +736,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20211217234328-ead591c0f22d
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
 # github.com/prometheus/prometheus v2.9.2+incompatible => github.com/prometheus/prometheus v1.8.2-0.20190424153033-d3245f150225
 # github.com/vmware/govmomi => github.com/libopenstorage/govmomi v0.22.3-0.20200619175019-4b44cc8cf4d1
 # k8s.io/api => k8s.io/api v0.20.4


### PR DESCRIPTION
**What this PR does / why we need it**:

CreateKey(), PutKey() and DeleteKey() updated the configmap keys that they had not locked because they specified all keys to Patch(). This overwrote the updates made by other nodes under a different lock.

Now, we use the new PatchKeyLocked() interface provided by the sched-ops repo.

Vendored in the for-cloudops branch from sched-ops repo. This branch in sched-ops repo was created from the current sched-ops git-hash used by the cloudops repo. Then, cherry-picked all the changes in sched-ops that involved k8s/cores/configmap directory. Used the following command to identify the commits to cherry-pick to the for-cloudops branch in the sched-ops repo.

$ git log --oneline ead591c0f22d..master -- k8s/core/configmap

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-38340

**Special notes for your reviewer**:

