### PR TITLE
PWX-38340: vendor sched-ops from for-cloudops branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/oracle/oci-go-sdk/v65 v65.13.1
 	github.com/pborman/uuid v1.2.0
 	github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd
-	github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
+	github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a
 	github.com/prometheus/client_golang v1.11.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.1
@@ -103,7 +103,7 @@ require (
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a
 	github.com/prometheus/prometheus v2.9.2+incompatible => github.com/prometheus/prometheus v1.8.2-0.20190424153033-d3245f150225
 	github.com/vmware/govmomi => github.com/libopenstorage/govmomi v0.22.3-0.20200619175019-4b44cc8cf4d1
 	k8s.io/api => k8s.io/api v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -1140,8 +1140,8 @@ github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd h1:L/1So9aaNBBOKXUPL
 github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd/go.mod h1:srh8qY1VIUFoaJN5TWQ6yWkICy7OoyNZuAqT4JMgAgI=
 github.com/portworx/px-backup-api v1.0.1-0.20200915150042-274508e876ef/go.mod h1:puy7YVXeb6glot1vVCIePIiRLSwB//+rFtN2ZjvXeEw=
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c h1:S8ZTtGBvLCjmdjz8pa9I7iz5BD0wdAS/BTbDpiN1QTc=
-github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c/go.mod h1:5xy8TTt9m/8UGG8Hw5NHxwc/mctjCsmj7mpcR7jIFjI=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a h1:wrK6ZxEcUPHR73oxVn99iOPm9j5JtwaDkBdl0oRGiIQ=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a/go.mod h1:5xy8TTt9m/8UGG8Hw5NHxwc/mctjCsmj7mpcR7jIFjI=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145/go.mod h1:CkLAs/ojTzSu3SPyeDxc3qhsbRU78H5Xz1qJlj1Ap1U=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/vendor/github.com/portworx/sched-ops/k8s/core/configmap/types.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/configmap/types.go
@@ -79,10 +79,10 @@ type configMap struct {
 }
 
 type k8sLock struct {
-	wg       sync.WaitGroup
-	done     chan struct{}
-	unlocked bool
-	id       string
+	v1LockGen uint64
+	done      chan struct{}
+	unlocked  bool
+	id        string
 	sync.Mutex
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,7 +242,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/portworx/kvdb v0.0.0-20230405233801-87666830d3fd
 ## explicit; go 1.17
 github.com/portworx/kvdb
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c => github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a => github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a
 ## explicit; go 1.12
 github.com/portworx/sched-ops/k8s/common
 github.com/portworx/sched-ops/k8s/core
@@ -736,7 +736,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240812234536-cd5368ab990c
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240817145415-1b0e4be5649a
 # github.com/prometheus/prometheus v2.9.2+incompatible => github.com/prometheus/prometheus v1.8.2-0.20190424153033-d3245f150225
 # github.com/vmware/govmomi => github.com/libopenstorage/govmomi v0.22.3-0.20200619175019-4b44cc8cf4d1
 # k8s.io/api => k8s.io/api v0.20.4


### PR DESCRIPTION
**What this PR does / why we need it**:

Vendored in the for-cloudops branch from sched-ops repo to pick up the latest configmap changes.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-38340

**Special notes for your reviewer**:

